### PR TITLE
OpenMDAO deprecation errors fixed

### DIFF
--- a/pycycle/elements/cfd_start.py
+++ b/pycycle/elements/cfd_start.py
@@ -1,29 +1,31 @@
-import numpy as np
-
 import openmdao.api as om
 
 from pycycle.cea import species_data
 from pycycle.constants import AIR_MIX
 from pycycle.elements.flow_start import FlowStart
 
+
 class CFDStart(om.Group):
 
     def initialize(self):
         self.options.declare('thermo_data', default=species_data.janaf,
-                              desc='thermodynamic data set', recordable=False)
+                             desc='thermodynamic data set', recordable=False)
         self.options.declare('elements', default=AIR_MIX,
-                              desc='set of elements present in the flow')
+                             desc='set of elements present in the flow')
 
     def setup(self):
         thermo_data = self.options['thermo_data']
         elements = self.options['elements']
 
-        self.add_subsystem('fs', FlowStart(thermo_data=thermo_data, elements=elements), promotes_outputs=['Fl_O:*'], promotes_inputs=['W'] )
+        self.add_subsystem('fs', FlowStart(thermo_data=thermo_data, elements=elements), promotes_outputs=['Fl_O:*'],
+                           promotes_inputs=['W'])
 
         balance = om.BalanceComp()
-        balance.add_balance('P', val=10., units='psi', eq_units='psi', lhs_name='Ps_computed', rhs_name='Ps', lower=1e-1)
+        balance.add_balance('P', val=10., units='psi', eq_units='psi', lhs_name='Ps_computed', rhs_name='Ps',
+                            lower=1e-1)
                             #guess_func=lambda inputs, resids: 5.)
-        balance.add_balance('T', val=800., units='degR', eq_units='ft/s', lhs_name='V_computed', rhs_name='V', lower=1e-1)
+        balance.add_balance('T', val=800., units='degR', eq_units='ft/s', lhs_name='V_computed', rhs_name='V',
+                            lower=1e-1)
                             #guess_func=lambda inputs, resids: 400.)
         balance.add_balance('MN', val=.3, eq_units='inch**2', lhs_name='area_computed', rhs_name='area', lower=1e-6)
                             #guess_func=lambda inputs, resids: .6)
@@ -51,7 +53,7 @@ if __name__ == "__main__":
 
     p = om.Problem()
 
-    params = p.model.add_subsystem('params', IndepVarComp(), promotes=['*'])
+    params = p.model.add_subsystem('params', om.IndepVarComp(), promotes=['*'])
     params.add_output('Ps', units='Pa', val=22845.15677648)
     params.add_output('V', units='m/s', val=158.83851913)
     params.add_output('area', units='m**2', val=0.87451328)

--- a/pycycle/elements/combustor.py
+++ b/pycycle/elements/combustor.py
@@ -20,11 +20,11 @@ class MixFuel(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('thermo_data', default=janaf,
-                              desc='thermodynamic data set', recordable=False)
+                             desc='thermodynamic data set', recordable=False)
         self.options.declare('inflow_elements', default=AIR_MIX,
-                              desc='set of elements present in the flow')
+                             desc='set of elements present in the flow')
         self.options.declare('fuel_type', default="JP-7",
-                              desc='Type of fuel.')
+                             desc='Type of fuel.')
 
     def setup(self):
         thermo_data = self.options['thermo_data']
@@ -190,17 +190,17 @@ class Combustor(om.Group):
 
     def initialize(self):
         self.options.declare('thermo_data', default=janaf,
-                              desc='thermodynamic data set', recordable=False)
+                             desc='thermodynamic data set', recordable=False)
         self.options.declare('inflow_elements', default=AIR_MIX,
-                              desc='set of elements present in the air flow')
+                             desc='set of elements present in the air flow')
         self.options.declare('air_fuel_elements', default=AIR_FUEL_MIX,
-                              desc='set of elements present in the fuel')
+                             desc='set of elements present in the fuel')
         self.options.declare('design', default=True,
-                              desc='Switch between on-design and off-design calculation.')
+                             desc='Switch between on-design and off-design calculation.')
         self.options.declare('statics', default=True,
-                              desc='If True, calculate static properties.')
+                             desc='If True, calculate static properties.')
         self.options.declare('fuel_type', default="JP-7",
-                              desc='Type of fuel.')
+                             desc='Type of fuel.')
 
     def setup(self):
         thermo_data = self.options['thermo_data']
@@ -286,15 +286,15 @@ if __name__ == "__main__":
 
     p = om.Problem()
     p.model = om.Group()
-    p.model.add('comp', MixFuel(), promotes=['*'])
+    p.model.add_subsystem('comp', MixFuel(), promotes=['*'])
 
-    p.model.add('d1', IndepVarComp('Fl_I:stat:W', val=1.0, units='lbm/s', desc='weight flow'),
-                promotes=['*'])
-    p.model.add('d2', IndepVarComp('Fl_I:FAR', val=0.2, desc='Fuel to air ratio'), promotes=['*'])
-    p.model.add('d3', IndepVarComp('Fl_I:tot:h', val=1.0, units='Btu/lbm', desc='total enthalpy'),
-                promotes=['*'])
-    p.model.add('d4', IndepVarComp('fuel_Tt', val=518.0, units='degR', desc='fuel temperature'),
-                promotes=['*'])
+    p.model.add_subsystem('d1', om.IndepVarComp('Fl_I:stat:W', val=1.0, units='lbm/s', desc='weight flow'),
+                          promotes=['*'])
+    p.model.add_subsystem('d2', om.IndepVarComp('Fl_I:FAR', val=0.2, desc='Fuel to air ratio'), promotes=['*'])
+    p.model.add_subsystem('d3', om.IndepVarComp('Fl_I:tot:h', val=1.0, units='Btu/lbm', desc='total enthalpy'),
+                          promotes=['*'])
+    p.model.add_subsystem('d4', om.IndepVarComp('fuel_Tt', val=518.0, units='degR', desc='fuel temperature'),
+                          promotes=['*'])
 
     p.setup(check=False)
     p.run_model()

--- a/pycycle/elements/compressor.py
+++ b/pycycle/elements/compressor.py
@@ -1,5 +1,5 @@
 import numpy as np
-from collections import Iterable
+from collections.abc import Iterable
 import itertools
 
 import openmdao.api as om

--- a/pycycle/elements/compressor_map.py
+++ b/pycycle/elements/compressor_map.py
@@ -1,9 +1,5 @@
 import openmdao.api as om
 
-from pycycle.maps.ncp01 import NCP01
-
-import numpy as np
-
 
 class StallCalcs(om.ExplicitComponent):
     """Component to compute the stall margins at constant speed (SMN) and constant flow (SMW)"""

--- a/pycycle/elements/compressor_map.py
+++ b/pycycle/elements/compressor_map.py
@@ -1,5 +1,9 @@
 import openmdao.api as om
 
+from pycycle.maps.ncp01 import NCP01
+
+import numpy as np
+
 
 class StallCalcs(om.ExplicitComponent):
     """Component to compute the stall margins at constant speed (SMN) and constant flow (SMW)"""

--- a/pycycle/elements/cooling.py
+++ b/pycycle/elements/cooling.py
@@ -1,12 +1,11 @@
-import numpy as np
-
 import openmdao.api as om
 
-from pycycle.constants import AIR_MIX, AIR_FUEL_MIX
 from pycycle.cea import species_data
 from pycycle.cea.set_total import SetTotal
-from pycycle.flow_in import FlowIn
+from pycycle.constants import AIR_MIX, AIR_FUEL_MIX
 from pycycle.elements.turbine import Bleeds
+from pycycle.flow_in import FlowIn
+
 
 class CombineCooling(om.ExplicitComponent):
 
@@ -26,7 +25,6 @@ class CombineCooling(om.ExplicitComponent):
         for i in range(1, self.options['n_ins']+1):
             W_cool += inputs['W_{}'.format(i)]
         outputs['W_cool'] = W_cool
-
 
 
 class CoolingCalcs(om.ExplicitComponent):

--- a/pycycle/elements/flow_start.py
+++ b/pycycle/elements/flow_start.py
@@ -5,6 +5,7 @@ from pycycle.cea.set_total import SetTotal
 from pycycle.cea.set_static import SetStatic
 from pycycle.constants import AIR_MIX
 
+
 class FlowStart(Group):
 
     def initialize(self):
@@ -91,7 +92,7 @@ if __name__ == "__main__":
     print("Pressure", p['P'], p['Fl_O:tot:P'])
     print("h", p['totals.h'], p['Fl_O:tot:h'])
     print("S", p['totals.S'])
-    print("actual Ps", p['exit_static.Ps'],p['Fl_O:stat:P'])
+    print("actual Ps", p['exit_static.Ps'], p['Fl_O:stat:P'])
     print("Mach", p['Fl_O:stat:MN'])
     print("n tot", p['Fl_O:tot:n'])
     print("n stat", p['Fl_O:stat:n'])

--- a/pycycle/elements/gearbox.py
+++ b/pycycle/elements/gearbox.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 import openmdao.api as om
 
 

--- a/pycycle/elements/mixer.py
+++ b/pycycle/elements/mixer.py
@@ -1,14 +1,11 @@
 import numpy as np
-
 import openmdao.api as om
 
-from pycycle.cea.set_total import SetTotal
 from pycycle.cea.set_static import SetStatic
+from pycycle.cea.set_total import SetTotal
 from pycycle.cea.species_data import Thermo, janaf
 from pycycle.constants import AIR_FUEL_MIX, AIR_MIX
-from pycycle.elements.duct import PressureLoss
 from pycycle.flow_in import FlowIn
-from pycycle.passthrough import PassThrough
 
 
 class MixFlow(om.ExplicitComponent):

--- a/pycycle/elements/nozzle.py
+++ b/pycycle/elements/nozzle.py
@@ -498,7 +498,7 @@ if __name__ == "__main__":
     # # p.model.MNth = 1.0
     # # p.model.throat_static.n2ls.Pt = 3.457820249
 
-    p.run()
+    p.run_model()
 
     # from openmdao.main.api import set_as_top
     # nozzle = set_as_top(Nozzle())

--- a/pycycle/elements/performance.py
+++ b/pycycle/elements/performance.py
@@ -101,13 +101,12 @@ class Performance(ExplicitComponent):
             J['PSFC', 'power'] = -3600. * wfuel / power ** 2
 
 
-
 if __name__ == "__main__":
     from openmdao.core.problem import Problem, IndepVarComp
 
     p = Problem()
 
-    des_vars = p.model.add('des_vars', IndepVarComp(), promotes=['*'])
+    des_vars = p.model.add_subsystem('des_vars', IndepVarComp(), promotes=['*'])
     des_vars.add_output('power', 200.0, units='hp')
     des_vars.add_output('Pt2', 204.696, units='psi')
     des_vars.add_output('Pt3', 104.696, units='psi')
@@ -116,10 +115,8 @@ if __name__ == "__main__":
     des_vars.add_output('Fg_0', 1200, units='lbf')
     des_vars.add_output('Fg_1', 2000, units='lbf')
 
-    p.model.add('comp', Performance(num_nozzles=2, num_burners=1), promotes=['*'])
+    p.model.add_subsystem('comp', Performance(num_nozzles=2, num_burners=1), promotes=['*'])
     # p.model.comp.fd_options['form'] = 'complex_step'
-
-
 
     p.setup(check=True)
     p.run_model()

--- a/pycycle/elements/shaft.py
+++ b/pycycle/elements/shaft.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from openmdao.api import ExplicitComponent
 
+
 class Shaft(ExplicitComponent):
 
     """Calculates power balance for shaft"""
@@ -132,14 +133,15 @@ class Shaft(ExplicitComponent):
                 J['pwr_out_real', trq_var_name] = Nmech * self.convert
                 J['pwr_net', trq_var_name] = Nmech * self.convert
 
+
 if __name__ == "__main__":
     from openmdao.api import Problem,  Group
 
     p = Problem()
     p.model = Group()
-    p.model.add("shaft", Shaft(10))
+    p.model.add_subsystem("shaft", Shaft(10))
 
     p.setup()
-    p.run()
+    p.run_model()
 
     #print(p['shaft.PortTrqs'])

--- a/pycycle/elements/turbine.py
+++ b/pycycle/elements/turbine.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 from copy import copy
 
 import numpy as np
@@ -676,7 +676,7 @@ class Turbine(om.Group):
 
 
 if __name__ == "__main__":
-    from pycycle.elements.api import FlowStart
+    from pycycle.api import FlowStart
     from pycycle.cea import species_data
     from pycycle.constants import AIR_MIX, AIR_FUEL_MIX
     from pycycle.connect_flow import connect_flow

--- a/pycycle/elements/turbine_map.py
+++ b/pycycle/elements/turbine_map.py
@@ -162,6 +162,7 @@ class TurbineMap(om.Group):
             self.connect('scaledOutput.Np','map_bal.rhs:NpMap')
             self.connect('scaledOutput.Wp','map_bal.rhs:PRmap')
 
+
 if __name__ == "__main__":
     from pycycle.maps.lpt2269 import LPT2269
 


### PR DESCRIPTION
Fixed some syntax errors (syntax removed from OpenMDAO 3.0). Some examples, e.g. in `shaft.py` and `duct.py` are still broken.