### PR TITLE
Turbine bleeds don't copy elements from parent turbine 

### DIFF
--- a/example_cycles/N+3ref/N3_MDP.py
+++ b/example_cycles/N+3ref/N3_MDP.py
@@ -342,8 +342,8 @@ newton.linesearch.options['iprint'] = -1
 prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
 # setup the optimization
-prob.driver = om.pyOptSparseDriver()
-prob.driver.options['optimizer'] = 'SNOPT'
+prob.driver = om.ScipyOptimizeDriver()
+prob.driver.options['optimizer'] = 'SLSQP'
 prob.driver.options['debug_print'] = ['desvars', 'nl_cons', 'objs']
 prob.driver.opt_settings={'Major step limit': 0.05}
 

--- a/example_cycles/N+3ref/N3_MDP_Opt.py
+++ b/example_cycles/N+3ref/N3_MDP_Opt.py
@@ -397,8 +397,8 @@ prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
 
 # setup the optimization
-prob.driver = om.pyOptSparseDriver()
-prob.driver.options['optimizer'] = 'SNOPT'
+prob.driver = om.ScipyOptimizeDriver()
+prob.driver.options['optimizer'] = 'SLSQP'
 prob.driver.options['debug_print'] = ['desvars', 'nl_cons', 'objs']
 prob.driver.opt_settings={'Major step limit': 0.05}
 

--- a/example_cycles/N+3ref/N3ref.py
+++ b/example_cycles/N+3ref/N3ref.py
@@ -656,8 +656,8 @@ if __name__ == "__main__":
 
 
     # setup the optimization
-    prob.driver = om.pyOptSparseDriver()
-    prob.driver.options['optimizer'] = 'SNOPT'
+    prob.driver = om.ScipyOptimizeDriver()
+    prob.driver.options['optimizer'] = 'SLSQP'
     prob.driver.options['debug_print'] = ['desvars', 'nl_cons', 'objs']
     prob.driver.opt_settings={'Major step limit': 0.05}
 

--- a/pycycle/elements/turbine.py
+++ b/pycycle/elements/turbine.py
@@ -569,7 +569,7 @@ class Turbine(om.Group):
                                '{}:*'.format(BN)])
 
         # Calculate bleed parameters
-        blds = Bleeds(bleed_names=bleeds, main_flow_elements=elements)
+        blds = Bleeds(bleed_names=bleeds, main_flow_elements=elements, bld_flow_elements = bleed_elements)
         self.add_subsystem('blds', blds,
                            promotes_inputs=[('W_in', 'Fl_I:stat:W'),
                                             ('Pt_in', 'Fl_I:tot:P'), ('n_in', 'Fl_I:tot:n')] +


### PR DESCRIPTION
Noticed that the bleeds subsystem does not load the elements from the parent turbine. Fixed by adding it to the bleed declaration.