### PR TITLE
Fix Turbine and Combustor thermo_data

### DIFF
--- a/pycycle/elements/combustor.py
+++ b/pycycle/elements/combustor.py
@@ -32,7 +32,7 @@ class MixFuel(om.ExplicitComponent):
         fuel_type = self.options['fuel_type']
 
         self.mixed_elements = inflow_elements.copy()
-        self.mixed_elements.update(janaf.reactants[fuel_type])
+        self.mixed_elements.update(thermo_data.reactants[fuel_type]) #adds the fuel elements to the mix outflow
 
         inflow_thermo = Thermo(thermo_data, init_reacts=inflow_elements)
         self.inflow_prods = inflow_thermo.products
@@ -64,7 +64,7 @@ class MixFuel(om.ExplicitComponent):
         self.add_output('Wfuel', shape=1, units="lbm/s", desc="total fuel massflow out")
 
         for i, r in enumerate(self.air_fuel_prods):
-            self.init_fuel_amounts_base[i] = janaf.reactants[fuel_type].get(r, 0) * janaf.products[r]['wt']
+            self.init_fuel_amounts_base[i] = thermo_data.reactants[fuel_type].get(r, 0) * thermo_data.products[r]['wt']
 
         # create a mapping between the composition indices of the inflow and outflow arrays
         self.in_out_flow_idx_map = [self.air_fuel_prods.index(prod) for prod in self.inflow_prods]

--- a/pycycle/elements/turbine.py
+++ b/pycycle/elements/turbine.py
@@ -172,7 +172,7 @@ class Bleeds(om.ExplicitComponent):
                               desc='thermodynamic data set', recordable=False)
         self.options.declare('main_flow_elements',
                               desc='set of elements present in the flow')
-        self.options.declare('bld_flow_elements', default=AIR_MIX,
+        self.options.declare('bld_flow_elements',
                               desc='set of elements present in the flow')
         self.options.declare('bleed_names', types=Iterable, desc='list of names for the bleed ports',
                               default=[])
@@ -569,7 +569,8 @@ class Turbine(om.Group):
                                '{}:*'.format(BN)])
 
         # Calculate bleed parameters
-        blds = Bleeds(bleed_names=bleeds, main_flow_elements=elements, bld_flow_elements = bleed_elements)
+        blds = Bleeds(bleed_names=bleeds, thermo_data = thermo_data, 
+                main_flow_elements=elements, bld_flow_elements = bleed_elements)
         self.add_subsystem('blds', blds,
                            promotes_inputs=[('W_in', 'Fl_I:stat:W'),
                                             ('Pt_in', 'Fl_I:tot:P'), ('n_in', 'Fl_I:tot:n')] +


### PR DESCRIPTION
Combustor and Turbine bleeds were not being given the right `thermo_data`. Fixed by passing it when instantiating the bleeds within the turbine. 