### PR TITLE
Add option to disable computing static properties on FlowStart

### DIFF
--- a/pycycle/thermo/unit_comps.py
+++ b/pycycle/thermo/unit_comps.py
@@ -23,7 +23,7 @@ class UnitCompBase(ExplicitComponent):
 
             meta = rel2meta[in_name]
             new_meta = {k:v for k, v in meta.items() if k in _allowed_out_args}
-            meta_val = meta['val']
+            meta_val = meta['value']
             if isinstance(meta_val, float): 
                 val = meta_val
             else: 

--- a/pycycle/thermo/unit_comps.py
+++ b/pycycle/thermo/unit_comps.py
@@ -23,7 +23,7 @@ class UnitCompBase(ExplicitComponent):
 
             meta = rel2meta[in_name]
             new_meta = {k:v for k, v in meta.items() if k in _allowed_out_args}
-            meta_val = meta['value']
+            meta_val = meta['val']
             if isinstance(meta_val, float): 
                 val = meta_val
             else: 


### PR DESCRIPTION
Option is useful when dealing with a configuration that doesn't compute static properties on any components but FlowStart.

This change saves a bit of computational time, but also can handle an edge-case where mass flow is zero without error.