### PR TITLE
Added variables to viewer, removed IVC from compressor and turbine map, and lowered hpt map speed bound

### DIFF
--- a/pycycle/elements/compressor_map.py
+++ b/pycycle/elements/compressor_map.py
@@ -183,10 +183,8 @@ class CompressorMap(om.Group):
         # Create instance of map for evaluating actual operating point
         if design:
             # In design mode, operating point specified by default values for RlineMap, NcMap and alphaMap
-            mapDesPt = om.IndepVarComp()
-            mapDesPt.add_output('NcMap', val=map_data.defaults['NcMap'], units='rpm')
-            mapDesPt.add_output('RlineMap', val=map_data.defaults['RlineMap'], units=None)
-            self.add_subsystem('mapDesPt', subsys=mapDesPt, promotes=['*'])
+            self.set_input_defaults('RlineMap', val=map_data.defaults['RlineMap'], units=None)
+            self.set_input_defaults('NcMap', val=map_data.defaults['NcMap'], units='rpm')
 
             # Evaluate map using design point values
             self.add_subsystem('map', readmap, promotes_inputs=['RlineMap', 'NcMap', 'alphaMap'],

--- a/pycycle/elements/turbine_map.py
+++ b/pycycle/elements/turbine_map.py
@@ -127,10 +127,8 @@ class TurbineMap(om.Group):
 
         if design:
             # In design mode, operating point specified by default values for RlineMap, NcMap and alphaMap
-            mapDesPt = om.IndepVarComp()
-            mapDesPt.add_output('NpMap', val=map_data.defaults['NpMap'], units='rpm')
-            mapDesPt.add_output('PRmap', val=map_data.defaults['PRmap'], units=None)
-            self.add_subsystem('mapDesPt', subsys=mapDesPt, promotes=['*'])
+            self.set_input_defaults('NpMap', val=map_data.defaults['NpMap'], units='rpm')
+            self.set_input_defaults('PRmap', val=map_data.defaults['PRmap'], units=None)
 
             # Evaluate map using design point values
             self.add_subsystem('readMap', readmap, promotes_inputs=['alphaMap', 'NpMap', 'PRmap'],
@@ -153,7 +151,7 @@ class TurbineMap(om.Group):
 
             # Use balance component to vary NpMap and PRmap to match incoming corrected flow and speed
             map_bal = om.BalanceComp()
-            map_bal.add_balance('NpMap', val=map_data.defaults['NpMap'], units='rpm', eq_units='rpm', lower=1., upper=200.)
+            map_bal.add_balance('NpMap', val=map_data.defaults['NpMap'], units='rpm', eq_units='rpm', lower=.1, upper=200.)
             map_bal.add_balance('PRmap', val=map_data.defaults['PRmap'], units=None,
                                 eq_units='lbm/s', lower=1.01)
             self.add_subsystem(name='map_bal', subsys=map_bal,

--- a/pycycle/mp_cycle.py
+++ b/pycycle/mp_cycle.py
@@ -138,7 +138,7 @@ class Cycle(om.Group):
                         # 1) there is a sub-cycle that you need to push into 
                         #        in this case, get the containing sub-cycle and push some starting nodes into its graph based on this linkage
                         # 2) they made a mistake in the element name, so throw an error
-                        print(node_parents[link[1]])
+                        # print(node_parents[link[1]])
 
                         out_port = node_port_names[node]
                         in_port = node_port_names[link[1]]

--- a/pycycle/viewers.py
+++ b/pycycle/viewers.py
@@ -42,19 +42,19 @@ def print_flow_station(prob, fs_names, file=sys.stdout):
 
 def print_compressor(prob, element_names, file=sys.stdout):
 
-    len_header = 17+12*13
+    len_header = 17+14*13
     # print("-"*len_header)
     print("-"*len_header, file=file, flush=True)
     print("                          COMPRESSOR PROPERTIES", file=file, flush=True)
     print("-"*len_header, file=file, flush=True)
 
-    line_tmpl = '{:<14}|  '+'{:>11}'*12
-    print(line_tmpl.format('Compressor', 'Wc', 'Pr', 'eta_a', 'eta_p', 'Nc', 'pwr', 'RlineMap', 'NcMap', 'PRmap', 'alphaMap', 'SMN', 'SMW'),
+    line_tmpl = '{:<14}|  '+'{:>11}'*14
+    print(line_tmpl.format('Compressor', 'Wc', 'Pr', 'eta_a', 'eta_p', 'Nc', 'pwr', 'RlineMap', 'NcMap', 'WcMap', 'PRmap', 'alphaMap', 'SMN', 'SMW', 'effMap'),
           file=file, flush=True)
     print("-"*len_header, file=file, flush=True)
 
 
-    line_tmpl = '{:<14}|  '+'{:11.3f}'*12
+    line_tmpl = '{:<14}|  '+'{:11.3f}'*14
     for e_name in element_names:
         sys = prob.model._get_subsystem(e_name)
         if sys.options['design']:
@@ -66,8 +66,8 @@ def print_compressor(prob, element_names, file=sys.stdout):
 
         print(line_tmpl.format(e_name, prob[e_name+'.Wc'][0], PR_temp,
                                eff_temp, prob[e_name+'.eff_poly'][0], prob[e_name+'.Nc'][0], prob[e_name+'.power'][0],
-                               prob[e_name+'.map.RlineMap'][0], prob[e_name+'.map.NcMap'][0],prob[e_name+'.map.PRmap'][0],
-                               prob[e_name+'.map.map.alphaMap'][0], prob[e_name+'.SMN'][0], prob[e_name+'.SMW'][0]),
+                               prob[e_name+'.map.RlineMap'][0], prob[e_name+'.map.NcMap'][0],prob[e_name+'.map.PRmap'][0], prob[e_name+'.map.WcMap'][0],
+                               prob[e_name+'.map.map.alphaMap'][0], prob[e_name+'.SMN'][0], prob[e_name+'.SMW'][0], prob[e_name+'.map.effMap'][0]),
               file=file, flush=True)
     print("-"*len_header, file=file, flush=True)
 
@@ -96,17 +96,17 @@ def print_burner(prob, element_names, file=sys.stdout):
 
 def print_turbine(prob, element_names, file=sys.stdout):
 
-    len_header = 17+7*13
+    len_header = 17+9*13
     print("-"*len_header, file=file, flush=True)
     print("                            TURBINE PROPERTIES", file=file, flush=True)
     print("-"*len_header, file=file, flush=True)
 
-    line_tmpl = '{:<14}|  '+'{:>13}'*7
-    print(line_tmpl.format('Turbine', 'Wp', 'PR', 'eff', 'Np', 'pwr', 'NpMap', 'PRmap'),
+    line_tmpl = '{:<14}|  '+'{:>13}'*9
+    print(line_tmpl.format('Turbine', 'Wp', 'PR', 'eff_a', 'eff_p', 'Np', 'pwr', 'NpMap', 'PRmap', 'alphaMap'),
         file=file, flush=True)
 
 
-    line_tmpl = '{:<14}|  '+'{:13.3f}'*7
+    line_tmpl = '{:<14}|  '+'{:13.3f}'*9
     for e_name in element_names:
         sys = prob.model._get_subsystem(e_name)
         if sys.options['design']:
@@ -117,8 +117,8 @@ def print_turbine(prob, element_names, file=sys.stdout):
           eff_temp = prob[e_name+'.eff'][0]
 
         print(line_tmpl.format(e_name, prob[e_name+'.Wp'][0], PR_temp,
-                               eff_temp, prob[e_name+'.Np'][0], prob[e_name+'.power'][0],
-                               prob[e_name+'.map.NpMap'][0], prob[e_name+'.map.PRmap'][0]),
+                               eff_temp, prob[e_name+'.eff_poly'][0], prob[e_name+'.Np'][0], prob[e_name+'.power'][0],
+                               prob[e_name+'.map.NpMap'][0], prob[e_name+'.map.PRmap'][0], prob[e_name+'.map.alphaMap'][0]),
               file=file, flush=True)
 
 


### PR DESCRIPTION
The IVC in the compressor and turbine maps was replaced with a set_input_defaults call in order to be able to control that variable at a higher level. The viewer was also expanded to include a few more variables, and the HPT map speed bound was lowered to account for maps scaled to 1 instead of 100. This branch has passed all regular and benchmark tests.