### PR TITLE
fix tests that used component as model

### DIFF
--- a/pycycle/thermo/cea/test/test_thermo_add_cea.py
+++ b/pycycle/thermo/cea/test/test_thermo_add_cea.py
@@ -12,8 +12,8 @@ from pycycle.constants import CEA_AIR_COMPOSITION, CEA_AIR_FUEL_COMPOSITION
 from pycycle.thermo.cea.thermo_add import ThermoAdd
 
 class ThermoAddTestCase(unittest.TestCase):
-    
-    def test_mix_1fuel(self): 
+
+    def test_mix_1fuel(self):
 
         thermo_spec = species_data.janaf
 
@@ -22,11 +22,11 @@ class ThermoAddTestCase(unittest.TestCase):
         p = om.Problem()
 
         fuel = 'JP-7'
-        p.model = ThermoAdd(spec=thermo_spec,
-                            inflow_composition=CEA_AIR_COMPOSITION, mix_mode='reactant', 
-                            mix_composition=fuel, mix_names='fuel')
-
-
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(spec=thermo_spec,
+                                        inflow_composition=CEA_AIR_COMPOSITION, mix_mode='reactant',
+                                        mix_composition=fuel, mix_names='fuel'),
+                              promotes=['*'])
 
         p.setup(force_alloc_complex=True)
 
@@ -50,7 +50,7 @@ class ThermoAddTestCase(unittest.TestCase):
         data = p.check_partials(method='fd')
         assert_check_partials(data, atol=2.e-4, rtol=2.e-4) # can't get very accurate checks with FD
 
-    def test_mix_2fuel(self): 
+    def test_mix_2fuel(self):
 
         thermo_spec = species_data.janaf
 
@@ -59,10 +59,11 @@ class ThermoAddTestCase(unittest.TestCase):
         p = om.Problem()
 
         fuel = 'JP-7'
-        p.model = ThermoAdd(spec=thermo_spec,
-                            inflow_composition=CEA_AIR_COMPOSITION, mix_mode='reactant', 
-                            mix_composition=[fuel, fuel], mix_names=['fuel1','fuel2'])
-
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(spec=thermo_spec,
+                                        inflow_composition=CEA_AIR_COMPOSITION, mix_mode='reactant',
+                                        mix_composition=[fuel, fuel], mix_names=['fuel1','fuel2']),
+                              promotes=['*'])
 
         p.setup(force_alloc_complex=True)
 
@@ -90,21 +91,23 @@ class ThermoAddTestCase(unittest.TestCase):
         # data = p.check_partials(method='cs')
         assert_check_partials(data, atol=2.e-4, rtol=2.e-4) # can't get very accurate checks with FD
 
-    def test_mix_1flow(self): 
+    def test_mix_1flow(self):
 
-        thermo_spec = species_data.janaf 
+        thermo_spec = species_data.janaf
 
         p = om.Problem()
 
-        p.model = ThermoAdd(spec=thermo_spec,
-                            inflow_composition=CEA_AIR_FUEL_COMPOSITION, mix_mode='flow', 
-                            mix_composition=CEA_AIR_COMPOSITION, mix_names='mix')
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(spec=thermo_spec,
+                                        inflow_composition=CEA_AIR_FUEL_COMPOSITION, mix_mode='flow',
+                                        mix_composition=CEA_AIR_COMPOSITION, mix_names='mix'),
+                               promotes=['*'])
 
         p.setup(force_alloc_complex=True)
 
         p['Fl_I:stat:W'] = 62.15
         p['Fl_I:tot:composition'] = [0.000313780313538, 0.0021127831122, 0.004208814234964, 0.052325087161902, 0.014058631311261]
-        p['Fl_I:tot:h'] = 10. 
+        p['Fl_I:tot:h'] = 10.
 
         p['mix:W'] = 4.44635
         p['mix:composition'] = [3.23319258e-04, 1.10132241e-05, 5.39157736e-02, 1.44860147e-02]
@@ -116,15 +119,17 @@ class ThermoAddTestCase(unittest.TestCase):
         assert_near_equal(p['composition_out'], np.array([0.00031442, 0.00197246, 0.00392781, 0.05243129, 0.01408717]), tolerance=tol)
         assert_near_equal(p['mass_avg_h'], (62.15*10+4.44635*5)/(62.15+4.44635), tol)
 
-    def test_mix_2flow(self): 
+    def test_mix_2flow(self):
 
-        thermo_spec = species_data.janaf 
+        thermo_spec = species_data.janaf
 
         p = om.Problem()
 
-        p.model = ThermoAdd(spec=thermo_spec,
-                            inflow_composition=CEA_AIR_FUEL_COMPOSITION, mix_mode='flow', 
-                            mix_composition=[CEA_AIR_COMPOSITION, CEA_AIR_COMPOSITION], mix_names=['mix1', 'mix2'])
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(spec=thermo_spec,
+                                        inflow_composition=CEA_AIR_FUEL_COMPOSITION, mix_mode='flow',
+                                        mix_composition=[CEA_AIR_COMPOSITION, CEA_AIR_COMPOSITION], mix_names=['mix1', 'mix2']),
+                              promotes=['*'])
 
         p.setup(force_alloc_complex=True)
 
@@ -145,7 +150,6 @@ class ThermoAddTestCase(unittest.TestCase):
         # assert_near_equal(p['composition_out'], np.array([0.0003149, 0.00186566, 0.00371394, 0.05251212, 0.01410888]), tolerance=tol)
         assert_near_equal(p['composition_out'], np.array([0.00031442, 0.00197246, 0.00392781, 0.05243129, 0.01408717]), tolerance=tol)
 
-
     def test_war_vals(self):
         """
         verifies that the ThermoAdd component gives the right answers when adding water to dry air
@@ -158,10 +162,8 @@ class ThermoAddTestCase(unittest.TestCase):
         air_thermo = species_data.Properties(thermo_spec, init_elements=CEA_AIR_COMPOSITION)
 
         prob.model.add_subsystem('war', ThermoAdd(spec=thermo_spec,
-                                                  inflow_composition=CEA_AIR_COMPOSITION, mix_composition='Water'), 
+                                                  inflow_composition=CEA_AIR_COMPOSITION, mix_composition='Water'),
                                  promotes=['*'])
-        
-
 
         prob.setup(force_alloc_complex=True)
 
@@ -182,8 +184,6 @@ class ThermoAddTestCase(unittest.TestCase):
         assert_near_equal(prob['composition_out'][4], 1.44901169e-02, tol)
 
 
-
-
-if __name__ == "__main__": 
+if __name__ == "__main__":
 
     unittest.main()

--- a/pycycle/thermo/tabular/test/test_thermo_add.py
+++ b/pycycle/thermo/tabular/test/test_thermo_add.py
@@ -9,15 +9,16 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from pycycle.thermo.tabular.thermo_add import ThermoAdd
 
 
-class ThermoAddTestCase(unittest.TestCase): 
+class ThermoAddTestCase(unittest.TestCase):
 
-    def test_mix_1fuel(self): 
+    def test_mix_1fuel(self):
 
         p = om.Problem()
-        p.model = ThermoAdd(mix_mode='reactant', mix_composition='FAR', mix_names='fuel')
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(mix_mode='reactant', mix_composition='FAR', mix_names='fuel'),
+                              promotes=['*'])
 
         p.setup(force_alloc_complex=True)
-
 
         p['Fl_I:stat:W'] = 1.
         p['Fl_I:tot:h'] = 181.381769
@@ -42,10 +43,12 @@ class ThermoAddTestCase(unittest.TestCase):
         assert_near_equal(p['fuel:W'], W_fuel_mix, tolerance=tol)
         assert_near_equal(p['composition_out'], (W_fuel_in+W_fuel_mix)/W_air_in, tolerance=tol)
 
-    def test_mix_2fuel(self): 
+    def test_mix_2fuel(self):
 
         p = om.Problem()
-        p.model = ThermoAdd(mix_mode='reactant', mix_composition='FAR', mix_names=['fuel1', 'fuel2'])
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(mix_mode='reactant', mix_composition='FAR', mix_names=['fuel1', 'fuel2']),
+                              promotes=['*'])
 
         p.setup(force_alloc_complex=True)
 
@@ -74,10 +77,12 @@ class ThermoAddTestCase(unittest.TestCase):
         assert_near_equal(p['fuel1:W'], p['Fl_I:stat:W']*ratio, tolerance=tol)
 
 
-    def test_mix_1flow(self): 
+    def test_mix_1flow(self):
 
         p = om.Problem()
-        p.model = ThermoAdd(mix_mode='flow', mix_composition='FAR', mix_names='mix')
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(mix_mode='flow', mix_composition='FAR', mix_names='mix'),
+                              promotes=['*'])
 
         p.setup(force_alloc_complex=True)
 
@@ -110,10 +115,12 @@ class ThermoAddTestCase(unittest.TestCase):
         assert_near_equal(p['mass_avg_h'], mass_avg_h, tol)
 
 
-    def test_mix_2flow(self): 
+    def test_mix_2flow(self):
 
         p = om.Problem()
-        p.model = ThermoAdd(mix_mode='flow', mix_composition='FAR', mix_names=['mix1', 'mix2'])
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(mix_mode='flow', mix_composition='FAR', mix_names=['mix1', 'mix2']),
+                              promotes=['*'])
 
         p.setup(force_alloc_complex=True)
 
@@ -154,11 +161,13 @@ class ThermoAddTestCase(unittest.TestCase):
         assert_near_equal(p['mass_avg_h'], mass_avg_h, tol)
 
 
-    def test_mix_1flow2compo(self): 
+    def test_mix_1flow2compo(self):
 
         p = om.Problem()
-        p.model = ThermoAdd(mix_mode='flow', inflow_composition={'FAR':0., 'WAR':0.}, 
-                            mix_names='mix1')
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(mix_mode='flow', inflow_composition={'FAR':0., 'WAR':0.}, 
+                                        mix_names='mix1'),
+                              promotes=['*'])
 
         p.setup(force_alloc_complex=True)
 
@@ -179,11 +188,13 @@ class ThermoAddTestCase(unittest.TestCase):
         assert_near_equal(p['mass_avg_h'], 2., tol)
 
 
-    def test_mix_1fuel2compo(self): 
+    def test_mix_1fuel2compo(self):
 
         p = om.Problem()
-        p.model = ThermoAdd(mix_mode='reactant', inflow_composition={'FAR':0., 'WAR':0.}, 
-                            mix_composition='FAR', mix_names='fuel1')
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(mix_mode='reactant', inflow_composition={'FAR':0., 'WAR':0.}, 
+                                        mix_composition='FAR', mix_names='fuel1'),
+                              promotes=['*'])
 
         p.setup(force_alloc_complex=True)
 
@@ -213,11 +224,13 @@ class ThermoAddTestCase(unittest.TestCase):
         assert_near_equal(p['composition_out'][1], 0, tolerance=tol)
 
 
-    def test_mix_1water2compo(self): 
+    def test_mix_1water2compo(self):
 
         p = om.Problem()
-        p.model = ThermoAdd(mix_mode='reactant', inflow_composition={'FAR':0., 'WAR':0.}, 
-                            mix_composition='WAR', mix_names='water1')
+        p.model.add_subsystem('thermo_add',
+                              ThermoAdd(mix_mode='reactant', inflow_composition={'FAR':0., 'WAR':0.},
+                                        mix_composition='WAR', mix_names='water1'),
+                              promotes=['*'])
 
         p.setup(force_alloc_complex=True)
 
@@ -248,6 +261,6 @@ class ThermoAddTestCase(unittest.TestCase):
         assert_near_equal(p['composition_out'][0], W_fuel_in/W_air_in, tolerance=tol)
         assert_near_equal(p['composition_out'][1], (W_water_in+W_water_mix)/W_air_in, tolerance=tol)
 
-if __name__ == "__main__": 
+if __name__ == "__main__":
 
     unittest.main()


### PR DESCRIPTION
OpenMDAO v 3.26 will be coming out soon and it removes the deprecated ability to use a Component as the model.

See: https://github.com/OpenMDAO/OpenMDAO/pull/2869

This PR fixes the tests that are broken by that change.