### PR TITLE
changed several places where np.seterr was being called in order to keep the changes localized.

### DIFF
--- a/example_cycles/tests/benchmark_ab_turbojet.py
+++ b/example_cycles/tests/benchmark_ab_turbojet.py
@@ -59,432 +59,434 @@ class DesignTestCase(unittest.TestCase):
 
 
     def benchmark_case1(self):
-        np.seterr(divide='raise')
-
-        self.prob.run_model()
-        tol = 1e-5
-        print()
-
-        reg_data = 167.78120192079388
-        pyc = self.prob['DESIGN.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 13.500
-        pyc = self.prob['DESIGN.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.0177588
-        pyc = self.prob['DESIGN.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 4.44344812
-        pyc = self.prob['DESIGN.balance.turb_PR'][0]
-        print('HPT PR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 11800.00602
-        pyc = self.prob['DESIGN.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.80249303
-        pyc = self.prob['DESIGN.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1188.187733639949
-        pyc = self.prob['DESIGN.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-
-        print('#'*10)
-        print('# OD1')
-        print('#'*10)
-        reg_data = 167.7812019326619
-        pyc = self.prob['OD1.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 13.500
-        pyc = self.prob['OD1.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.01775886276199831
-        pyc = self.prob['OD1.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 8070.00
-        pyc = self.prob['OD1.balance.Nmech'][0]
-        print('HP Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 17673.630645166682
-        pyc = self.prob['OD1.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1.6131345333
-        pyc = self.prob['OD1.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1188.1877337
-        pyc = self.prob['OD1.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-
-        print('#'*10)
-        print('# OD2')
-        print('#'*10)
-        reg_data = 226.1582667
-        pyc = self.prob['OD2.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 11.97034442
-        pyc = self.prob['OD2.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.016484348
-        pyc = self.prob['OD2.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 8288.751672
-        pyc = self.prob['OD2.balance.Nmech'][0]
-        print('HP Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 24024.738726
-        pyc = self.prob['OD2.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1.71183305
-        pyc = self.prob['OD2.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1278.233868
-        pyc = self.prob['OD2.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-
-        print('#'*10)
-        print('# OD1dry')
-        print('#'*10)
-        reg_data = 167.7812019
-        pyc = self.prob['OD1dry.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 13.500
-        pyc = self.prob['OD1dry.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.01775886
-        pyc = self.prob['OD1dry.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 8070.00
-        pyc = self.prob['OD1dry.balance.Nmech'][0]
-        print('HP Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 11800.00602
-        pyc = self.prob['OD1dry.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.80249303
-        pyc = self.prob['OD1dry.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1188.187733
-        pyc = self.prob['OD1dry.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        print('#'*10)
-        print('# OD2dry')
-        print('#'*10)
-        reg_data = 226.158267
-        pyc = self.prob['OD2dry.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 11.9703444
-        pyc = self.prob['OD2dry.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.016484348
-        pyc = self.prob['OD2dry.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 8288.751674
-        pyc = self.prob['OD2dry.balance.Nmech'][0]
-        print('HP Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 17263.807784
-        pyc = self.prob['OD2dry.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1.0785433412
-        pyc = self.prob['OD2dry.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1278.233868
-        pyc = self.prob['OD2dry.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        print('#'*10)
-        print('# OD3')
-        print('#'*10)
-        reg_data = 167.0537804
-        pyc = self.prob['OD3dry.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 12.5255004
-        pyc = self.prob['OD3dry.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.0169796
-        pyc = self.prob['OD3dry.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 8197.2178375
-        pyc = self.prob['OD3dry.balance.Nmech'][0]
-        print('HP Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 13978.106823
-        pyc = self.prob['OD3dry.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1.0621843383
-        pyc = self.prob['OD3dry.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1243.395077
-        pyc = self.prob['OD3dry.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        print('#'*10)
-        print('# OD4')
-        print('#'*10)
-        reg_data = 141.05599880
-        pyc = self.prob['OD4dry.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 12.635341223
-        pyc = self.prob['OD4dry.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.017071756
-        pyc = self.prob['OD4dry.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 8180.853747
-        pyc = self.prob['OD4dry.balance.Nmech'][0]
-        print('HP Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 12577.7442
-        pyc = self.prob['OD4dry.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1.0583853809
-        pyc = self.prob['OD4dry.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1236.912578
-        pyc = self.prob['OD4dry.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        print('#'*10)
-        print('# OD5 dry')
-        print('#'*10)
-        reg_data = 62.08668193
-        pyc = self.prob['OD5dry.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 16.95492445
-        pyc = self.prob['OD5dry.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.018923417
-        pyc = self.prob['OD5dry.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 8901.5303811
-        pyc = self.prob['OD5dry.balance.Nmech'][0]
-        print('HP Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 5148.015919
-        pyc = self.prob['OD5dry.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.9285676181
-        pyc = self.prob['OD5dry.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1105.04970532
-        pyc = self.prob['OD5dry.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        print('#'*10)
-        print('# OD6 dry')
-        print('#'*10)
-        reg_data = 146.2281497
-        pyc = self.prob['OD6dry.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 11.76520553
-        pyc = self.prob['OD6dry.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.016271478
-        pyc = self.prob['OD6dry.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 8326.43166292
-        pyc = self.prob['OD6dry.balance.Nmech'][0]
-        print('HP Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 14144.18906
-        pyc = self.prob['OD6dry.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1.07004953
-        pyc = self.prob['OD6dry.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1293.191306
-        pyc = self.prob['OD6dry.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        print('#'*10)
-        print('# OD7dry')
-        print('#'*10)
-        reg_data = 71.7685995
-        pyc = self.prob['OD7dry.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 11.87578349
-        pyc = self.prob['OD7dry.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.01639430
-        pyc = self.prob['OD7dry.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 8305.89555495
-        pyc = self.prob['OD7dry.balance.Nmech'][0]
-        print('HP Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 6965.1181098
-        pyc = self.prob['OD7dry.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1.065737783
-        pyc = self.prob['OD7dry.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1284.56340514
-        pyc = self.prob['OD7dry.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        print('#'*10)
-        print('# OD8dry')
-        print('#'*10)
-        reg_data = 33.5400276475
-        pyc = self.prob['OD8dry.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 10.740144458636
-        pyc = self.prob['OD8dry.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.0153433156
-        pyc = self.prob['OD8dry.balance.FAR'][0]
-        print('Main FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 8466.9052471
-        pyc = self.prob['OD8dry.balance.Nmech'][0]
-        print('HP Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 3314.4866922
-        pyc = self.prob['OD8dry.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1.0964228045193
-        pyc = self.prob['OD8dry.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1357.997875
-        pyc = self.prob['OD8dry.comp.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        print()
-
+        old = np.seterr(divide='raise')
+
+        try:
+            self.prob.run_model()
+            tol = 1e-5
+            print()
+
+            reg_data = 167.78120192079388
+            pyc = self.prob['DESIGN.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 13.500
+            pyc = self.prob['DESIGN.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.0177588
+            pyc = self.prob['DESIGN.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 4.44344812
+            pyc = self.prob['DESIGN.balance.turb_PR'][0]
+            print('HPT PR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 11800.00602
+            pyc = self.prob['DESIGN.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.80249303
+            pyc = self.prob['DESIGN.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1188.187733639949
+            pyc = self.prob['DESIGN.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+
+            print('#'*10)
+            print('# OD1')
+            print('#'*10)
+            reg_data = 167.7812019326619
+            pyc = self.prob['OD1.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 13.500
+            pyc = self.prob['OD1.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.01775886276199831
+            pyc = self.prob['OD1.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 8070.00
+            pyc = self.prob['OD1.balance.Nmech'][0]
+            print('HP Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 17673.630645166682
+            pyc = self.prob['OD1.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1.6131345333
+            pyc = self.prob['OD1.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1188.1877337
+            pyc = self.prob['OD1.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+
+            print('#'*10)
+            print('# OD2')
+            print('#'*10)
+            reg_data = 226.1582667
+            pyc = self.prob['OD2.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 11.97034442
+            pyc = self.prob['OD2.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.016484348
+            pyc = self.prob['OD2.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 8288.751672
+            pyc = self.prob['OD2.balance.Nmech'][0]
+            print('HP Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 24024.738726
+            pyc = self.prob['OD2.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1.71183305
+            pyc = self.prob['OD2.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1278.233868
+            pyc = self.prob['OD2.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+
+            print('#'*10)
+            print('# OD1dry')
+            print('#'*10)
+            reg_data = 167.7812019
+            pyc = self.prob['OD1dry.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 13.500
+            pyc = self.prob['OD1dry.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.01775886
+            pyc = self.prob['OD1dry.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 8070.00
+            pyc = self.prob['OD1dry.balance.Nmech'][0]
+            print('HP Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 11800.00602
+            pyc = self.prob['OD1dry.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.80249303
+            pyc = self.prob['OD1dry.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1188.187733
+            pyc = self.prob['OD1dry.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            print('#'*10)
+            print('# OD2dry')
+            print('#'*10)
+            reg_data = 226.158267
+            pyc = self.prob['OD2dry.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 11.9703444
+            pyc = self.prob['OD2dry.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.016484348
+            pyc = self.prob['OD2dry.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 8288.751674
+            pyc = self.prob['OD2dry.balance.Nmech'][0]
+            print('HP Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 17263.807784
+            pyc = self.prob['OD2dry.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1.0785433412
+            pyc = self.prob['OD2dry.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1278.233868
+            pyc = self.prob['OD2dry.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            print('#'*10)
+            print('# OD3')
+            print('#'*10)
+            reg_data = 167.0537804
+            pyc = self.prob['OD3dry.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 12.5255004
+            pyc = self.prob['OD3dry.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.0169796
+            pyc = self.prob['OD3dry.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 8197.2178375
+            pyc = self.prob['OD3dry.balance.Nmech'][0]
+            print('HP Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 13978.106823
+            pyc = self.prob['OD3dry.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1.0621843383
+            pyc = self.prob['OD3dry.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1243.395077
+            pyc = self.prob['OD3dry.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            print('#'*10)
+            print('# OD4')
+            print('#'*10)
+            reg_data = 141.05599880
+            pyc = self.prob['OD4dry.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 12.635341223
+            pyc = self.prob['OD4dry.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.017071756
+            pyc = self.prob['OD4dry.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 8180.853747
+            pyc = self.prob['OD4dry.balance.Nmech'][0]
+            print('HP Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 12577.7442
+            pyc = self.prob['OD4dry.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1.0583853809
+            pyc = self.prob['OD4dry.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1236.912578
+            pyc = self.prob['OD4dry.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            print('#'*10)
+            print('# OD5 dry')
+            print('#'*10)
+            reg_data = 62.08668193
+            pyc = self.prob['OD5dry.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 16.95492445
+            pyc = self.prob['OD5dry.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.018923417
+            pyc = self.prob['OD5dry.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 8901.5303811
+            pyc = self.prob['OD5dry.balance.Nmech'][0]
+            print('HP Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 5148.015919
+            pyc = self.prob['OD5dry.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.9285676181
+            pyc = self.prob['OD5dry.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1105.04970532
+            pyc = self.prob['OD5dry.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            print('#'*10)
+            print('# OD6 dry')
+            print('#'*10)
+            reg_data = 146.2281497
+            pyc = self.prob['OD6dry.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 11.76520553
+            pyc = self.prob['OD6dry.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.016271478
+            pyc = self.prob['OD6dry.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 8326.43166292
+            pyc = self.prob['OD6dry.balance.Nmech'][0]
+            print('HP Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 14144.18906
+            pyc = self.prob['OD6dry.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1.07004953
+            pyc = self.prob['OD6dry.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1293.191306
+            pyc = self.prob['OD6dry.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            print('#'*10)
+            print('# OD7dry')
+            print('#'*10)
+            reg_data = 71.7685995
+            pyc = self.prob['OD7dry.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 11.87578349
+            pyc = self.prob['OD7dry.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.01639430
+            pyc = self.prob['OD7dry.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 8305.89555495
+            pyc = self.prob['OD7dry.balance.Nmech'][0]
+            print('HP Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 6965.1181098
+            pyc = self.prob['OD7dry.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1.065737783
+            pyc = self.prob['OD7dry.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1284.56340514
+            pyc = self.prob['OD7dry.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            print('#'*10)
+            print('# OD8dry')
+            print('#'*10)
+            reg_data = 33.5400276475
+            pyc = self.prob['OD8dry.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 10.740144458636
+            pyc = self.prob['OD8dry.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.0153433156
+            pyc = self.prob['OD8dry.balance.FAR'][0]
+            print('Main FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 8466.9052471
+            pyc = self.prob['OD8dry.balance.Nmech'][0]
+            print('HP Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 3314.4866922
+            pyc = self.prob['OD8dry.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1.0964228045193
+            pyc = self.prob['OD8dry.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1357.997875
+            pyc = self.prob['OD8dry.comp.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            print()
+        finally:
+            np.seterr(**old)
 
 if __name__ == "__main__":
     unittest.main()

--- a/example_cycles/tests/benchmark_hbtf.py
+++ b/example_cycles/tests/benchmark_hbtf.py
@@ -26,20 +26,20 @@ class HBTFTestCase(unittest.TestCase):
 
         self.prob.set_val('DESIGN.hpc.PR', 9.369)
         self.prob.set_val('DESIGN.hpc.eff', 0.8707)
-        
+
         self.prob.set_val('DESIGN.hpt.eff', 0.8888)
         self.prob.set_val('DESIGN.lpt.eff', 0.8996)
-        
+
         self.prob.set_val('DESIGN.fc.alt', 35000., units='ft')
         self.prob.set_val('DESIGN.fc.MN', 0.8)
-        
+
         self.prob.set_val('DESIGN.T4_MAX', 2857, units='degR')
-        self.prob.set_val('DESIGN.Fn_DES', 5900.0, units='lbf') 
+        self.prob.set_val('DESIGN.Fn_DES', 5900.0, units='lbf')
 
         self.prob.set_val('OD_full_pwr.T4_MAX', 2857, units='degR')
         self.prob.set_val('OD_part_pwr.PC', 0.8)
 
-        
+
         # Set initial guesses for balances
         self.prob['DESIGN.balance.FAR'] = 0.025
         self.prob['DESIGN.balance.W'] = 100.
@@ -48,15 +48,15 @@ class HBTFTestCase(unittest.TestCase):
         self.prob['DESIGN.fc.balance.Pt'] = 5.2
         self.prob['DESIGN.fc.balance.Tt'] = 440.0
 
-        
+
         for pt in ['OD_full_pwr', 'OD_part_pwr']:
 
             # initial guesses
             self.prob[pt+'.balance.FAR'] = 0.02467
             self.prob[pt+'.balance.W'] = 300
             self.prob[pt+'.balance.BPR'] = 5.105
-            self.prob[pt+'.balance.lp_Nmech'] = 5000 
-            self.prob[pt+'.balance.hp_Nmech'] = 15000 
+            self.prob[pt+'.balance.lp_Nmech'] = 5000
+            self.prob[pt+'.balance.hp_Nmech'] = 15000
             self.prob[pt+'.hpt.PR'] = 3.
             self.prob[pt+'.lpt.PR'] = 4.
             self.prob[pt+'.fan.map.RlineMap'] = 2.0
@@ -65,153 +65,154 @@ class HBTFTestCase(unittest.TestCase):
 
 
     def benchmark_case1(self):
-        np.seterr(divide='raise')
+        old = np.seterr(divide='raise')
 
-        
-        self.prob.set_solver_print(level=-1)
-        self.prob.set_solver_print(level=2, depth=1)
-        self.prob.run_model()
-        tol = 1e-5
-        print()
+        try:
+            self.prob.set_solver_print(level=-1)
+            self.prob.set_solver_print(level=2, depth=1)
+            self.prob.run_model()
+            tol = 1e-5
+            print()
 
-        reg_data = 344.303
-        pyc = self.prob['DESIGN.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 344.303
+            pyc = self.prob['DESIGN.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 30.094
-        pyc = self.prob['DESIGN.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 30.094
+            pyc = self.prob['DESIGN.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 0.02491989
-        pyc = self.prob['DESIGN.balance.FAR'][0]
-        print('FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 0.02491989
+            pyc = self.prob['DESIGN.balance.FAR'][0]
+            print('FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 3.61475
-        pyc = self.prob['DESIGN.balance.hpt_PR'][0]
-        print('HPT PR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 3.61475
+            pyc = self.prob['DESIGN.balance.hpt_PR'][0]
+            print('HPT PR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 4.3656305
-        pyc = self.prob['DESIGN.balance.lpt_PR'][0]
-        print('LPT PR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 4.3656305
+            pyc = self.prob['DESIGN.balance.lpt_PR'][0]
+            print('LPT PR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 14232.2
-        pyc = self.prob['DESIGN.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 14232.2
+            pyc = self.prob['DESIGN.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 0.63071997
-        pyc = self.prob['DESIGN.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 0.63071997
+            pyc = self.prob['DESIGN.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 1276.47613
-        pyc = self.prob['DESIGN.bld3.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-
-        print('#'*10)
-        print('# OD_full_pwr')
-        print('#'*10)
-        reg_data = 344.303
-        pyc = self.prob['OD_full_pwr.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 30.0937151
-        pyc = self.prob['OD_full_pwr.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.0249198
-        pyc = self.prob['OD_full_pwr.balance.FAR'][0]
-        print('FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 14705.7
-        pyc = self.prob['OD_full_pwr.balance.hp_Nmech'][0]
-        print('HPT Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 4666.1
-        pyc = self.prob['OD_full_pwr.balance.lp_Nmech'][0]
-        print('LPT Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 14232.2
-        pyc = self.prob['OD_full_pwr.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 0.63071997
-        pyc = self.prob['OD_full_pwr.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 1276.48
-        pyc = self.prob['OD_full_pwr.bld3.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
-
-        reg_data = 5.105
-        pyc = self.prob['OD_full_pwr.balance.BPR'][0]
-        print('BPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 1276.47613
+            pyc = self.prob['DESIGN.bld3.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
 
-        print('#'*10)
-        print('# OD_part_pwr')
-        print('#'*10)
-        reg_data = 324.633
-        pyc = self.prob['OD_part_pwr.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            print('#'*10)
+            print('# OD_full_pwr')
+            print('#'*10)
+            reg_data = 344.303
+            pyc = self.prob['OD_full_pwr.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 25.21321086
-        pyc = self.prob['OD_part_pwr.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 30.0937151
+            pyc = self.prob['OD_full_pwr.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 0.0224776
-        pyc = self.prob['OD_part_pwr.balance.FAR'][0]
-        print('FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 0.0249198
+            pyc = self.prob['OD_full_pwr.balance.FAR'][0]
+            print('FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 14251.973
-        pyc = self.prob['OD_part_pwr.balance.hp_Nmech'][0]
-        print('HPT Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 14705.7
+            pyc = self.prob['OD_full_pwr.balance.hp_Nmech'][0]
+            print('HPT Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data =  4301.935
-        pyc = self.prob['OD_part_pwr.balance.lp_Nmech'][0]
-        print('LPT Nmech:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 4666.1
+            pyc = self.prob['OD_full_pwr.balance.lp_Nmech'][0]
+            print('LPT Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 12576.2
-        pyc = self.prob['OD_part_pwr.perf.Fg'][0]
-        print('Fg:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 14232.2
+            pyc = self.prob['OD_full_pwr.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 0.61883
-        pyc = self.prob['OD_part_pwr.perf.TSFC'][0]
-        print('TSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 0.63071997
+            pyc = self.prob['OD_full_pwr.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 1205.007
-        pyc = self.prob['OD_part_pwr.bld3.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 1276.48
+            pyc = self.prob['OD_full_pwr.bld3.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 5.614823
-        pyc = self.prob['OD_part_pwr.balance.BPR'][0]
-        print('BPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 5.105
+            pyc = self.prob['OD_full_pwr.balance.BPR'][0]
+            print('BPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
+
+            print('#'*10)
+            print('# OD_part_pwr')
+            print('#'*10)
+            reg_data = 324.633
+            pyc = self.prob['OD_part_pwr.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 25.21321086
+            pyc = self.prob['OD_part_pwr.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.0224776
+            pyc = self.prob['OD_part_pwr.balance.FAR'][0]
+            print('FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 14251.973
+            pyc = self.prob['OD_part_pwr.balance.hp_Nmech'][0]
+            print('HPT Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data =  4301.935
+            pyc = self.prob['OD_part_pwr.balance.lp_Nmech'][0]
+            print('LPT Nmech:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 12576.2
+            pyc = self.prob['OD_part_pwr.perf.Fg'][0]
+            print('Fg:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 0.61883
+            pyc = self.prob['OD_part_pwr.perf.TSFC'][0]
+            print('TSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 1205.007
+            pyc = self.prob['OD_part_pwr.bld3.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+
+            reg_data = 5.614823
+            pyc = self.prob['OD_part_pwr.balance.BPR'][0]
+            print('BPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
+        finally:
+            np.seterr(**old)
 
 if __name__ == "__main__":
     unittest.main()

--- a/example_cycles/tests/benchmark_multi_spool_turboshaft.py
+++ b/example_cycles/tests/benchmark_multi_spool_turboshaft.py
@@ -59,106 +59,109 @@ class MultiSpoolTestCase(unittest.TestCase):
         self.prob.set_solver_print(level=2, depth=1)
 
     def benchmark_case1(self):
-        np.seterr(divide='raise')
+        old = np.seterr(divide='raise')
 
-        self.prob.run_model()
-        tol = 1e-5
-        print()
+        try:
+            self.prob.run_model()
+            tol = 1e-5
+            print()
 
-        reg_data = 10.774726815
-        pyc = self.prob['DESIGN.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 10.774726815
+            pyc = self.prob['DESIGN.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 40.419000000000004
-        pyc = self.prob['DESIGN.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 40.419000000000004
+            pyc = self.prob['DESIGN.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 0.0213592428
-        pyc = self.prob['DESIGN.balance.FAR'][0]
-        print('FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 0.0213592428
+            pyc = self.prob['DESIGN.balance.FAR'][0]
+            print('FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 4.23253914
-        pyc = self.prob['DESIGN.balance.hpt_PR'][0]
-        print('HPT PR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 4.23253914
+            pyc = self.prob['DESIGN.balance.hpt_PR'][0]
+            print('HPT PR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 1.978929924
-        pyc = self.prob['DESIGN.balance.lpt_PR'][0]
-        print('LPT PR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 1.978929924
+            pyc = self.prob['DESIGN.balance.lpt_PR'][0]
+            print('LPT PR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 4.919002289
-        pyc = self.prob['DESIGN.balance.pt_PR'][0]
-        print('PT PR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 4.919002289
+            pyc = self.prob['DESIGN.balance.pt_PR'][0]
+            print('PT PR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 0.37581601
-        pyc = self.prob['DESIGN.nozzle.Fl_O:stat:MN'][0]
-        print('Nozz MN:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 0.37581601
+            pyc = self.prob['DESIGN.nozzle.Fl_O:stat:MN'][0]
+            print('Nozz MN:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 0.313564855
-        pyc = self.prob['DESIGN.perf.PSFC'][0]
-        print('PSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 0.313564855
+            pyc = self.prob['DESIGN.perf.PSFC'][0]
+            print('PSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 1377.8012797
-        pyc = self.prob['DESIGN.duct6.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 1377.8012797
+            pyc = self.prob['DESIGN.duct6.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        print('#'*10)
-        print('# OD')
-        print('#'*10)
-        reg_data = 10.23511401
-        pyc = self.prob['OD.inlet.Fl_O:stat:W'][0]
-        print('W:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            print('#'*10)
+            print('# OD')
+            print('#'*10)
+            reg_data = 10.23511401
+            pyc = self.prob['OD.inlet.Fl_O:stat:W'][0]
+            print('W:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 37.71143287
-        pyc = self.prob['OD.perf.OPR'][0]
-        print('OPR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 37.71143287
+            pyc = self.prob['OD.perf.OPR'][0]
+            print('OPR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 0.0202391534
-        pyc = self.prob['OD.balance.FAR'][0]
-        print('FAR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 0.0202391534
+            pyc = self.prob['OD.balance.FAR'][0]
+            print('FAR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 10.235114018
-        pyc = self.prob['OD.balance.W'][0]
-        print('HPT PR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 10.235114018
+            pyc = self.prob['OD.balance.W'][0]
+            print('HPT PR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 11557.417714
-        pyc = self.prob['OD.balance.IP_Nmech'][0]
-        print('LPT PR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 11557.417714
+            pyc = self.prob['OD.balance.IP_Nmech'][0]
+            print('LPT PR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 14620.2646120
-        pyc = self.prob['OD.balance.HP_Nmech'][0]
-        print('PT PR:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 14620.2646120
+            pyc = self.prob['OD.balance.HP_Nmech'][0]
+            print('PT PR:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 0.3525941
-        pyc = self.prob['OD.nozzle.Fl_O:stat:MN'][0]
-        print('Nozz MN:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 0.3525941
+            pyc = self.prob['OD.nozzle.Fl_O:stat:MN'][0]
+            print('Nozz MN:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 0.3175212620
-        pyc = self.prob['OD.perf.PSFC'][0]
-        print('PSFC:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 0.3175212620
+            pyc = self.prob['OD.perf.PSFC'][0]
+            print('PSFC:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        reg_data = 1345.9668282
-        pyc = self.prob['OD.duct6.Fl_O:tot:T'][0]
-        print('Tt3:', pyc, reg_data)
-        assert_near_equal(pyc, reg_data, tol)
+            reg_data = 1345.9668282
+            pyc = self.prob['OD.duct6.Fl_O:tot:T'][0]
+            print('Tt3:', pyc, reg_data)
+            assert_near_equal(pyc, reg_data, tol)
 
-        print()
+            print()
+        finally:
+            np.seterr(**old)
 
 if __name__ == "__main__":
     unittest.main()

--- a/example_cycles/tests/benchmark_simple_turbojet.py
+++ b/example_cycles/tests/benchmark_simple_turbojet.py
@@ -26,10 +26,10 @@ class SimpleTurbojetTestCase(unittest.TestCase):
         prob.set_val('DESIGN.fc.alt', 0, units='ft')
         prob.set_val('DESIGN.fc.MN', 0.000001)
         prob.set_val('DESIGN.balance.Fn_target', 11800.0, units='lbf')
-        prob.set_val('DESIGN.balance.T4_target', 2370.0, units='degR') 
-        
+        prob.set_val('DESIGN.balance.T4_target', 2370.0, units='degR')
+
         ##Values that will go away when set_input_defaults is fixed
-        prob.set_val('DESIGN.comp.PR', 13.5) 
+        prob.set_val('DESIGN.comp.PR', 13.5)
         prob.set_val('DESIGN.comp.eff', 0.83)
         prob.set_val('DESIGN.turb.eff', 0.86)
 
@@ -50,86 +50,87 @@ class SimpleTurbojetTestCase(unittest.TestCase):
             prob[pt+'.fc.balance.Tt'] = 558.31
             prob[pt+'.turb.PR'] = 4.6690
 
-        np.seterr(divide='raise')
+        old = np.seterr(divide='raise')
 
-        prob.run_model()
-        tol = 1e-5
-        print()
+        try:
+            prob.run_model()
+            tol = 1e-5
+            print()
 
-        reg_data = 147.333
-        ans = prob['DESIGN.inlet.Fl_O:stat:W'][0]
-        print('W:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 147.333
+            ans = prob['DESIGN.inlet.Fl_O:stat:W'][0]
+            print('W:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 13.500
-        ans = prob['DESIGN.perf.OPR'][0]
-        print('OPR:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 13.500
+            ans = prob['DESIGN.perf.OPR'][0]
+            print('OPR:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 0.01776487
-        ans = prob['DESIGN.balance.FAR'][0]
-        print('Main FAR:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 0.01776487
+            ans = prob['DESIGN.balance.FAR'][0]
+            print('Main FAR:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 3.8591364
-        ans = prob['DESIGN.balance.turb_PR'][0]
-        print('HPT PR:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 3.8591364
+            ans = prob['DESIGN.balance.turb_PR'][0]
+            print('HPT PR:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 11800.00455497
-        ans = prob['DESIGN.perf.Fg'][0]
-        print('Fg:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 11800.00455497
+            ans = prob['DESIGN.perf.Fg'][0]
+            print('Fg:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 0.7985165
-        ans = prob['DESIGN.perf.TSFC'][0]
-        print('TSFC:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 0.7985165
+            ans = prob['DESIGN.perf.TSFC'][0]
+            print('TSFC:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 1187.7610184
-        ans = prob['DESIGN.comp.Fl_O:tot:T'][0]
-        print('Tt3:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 1187.7610184
+            ans = prob['DESIGN.comp.Fl_O:tot:T'][0]
+            print('Tt3:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 142.786698
-        ans = prob['OD0.inlet.Fl_O:stat:W'][0]
-        print('W:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 142.786698
+            ans = prob['OD0.inlet.Fl_O:stat:W'][0]
+            print('W:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 12.8588424
-        ans = prob['OD0.perf.OPR'][0]
-        print('OPR:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 12.8588424
+            ans = prob['OD0.perf.OPR'][0]
+            print('OPR:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 0.01676938946
-        ans = prob['OD0.balance.FAR'][0]
-        print('Main FAR:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 0.01676938946
+            ans = prob['OD0.balance.FAR'][0]
+            print('Main FAR:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 7943.9331210
-        ans = prob['OD0.balance.Nmech'][0]
-        print('HP Nmech:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 7943.9331210
+            ans = prob['OD0.balance.Nmech'][0]
+            print('HP Nmech:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 11000.00488519
-        ans = prob['OD0.perf.Fg'][0]
-        print('Fg:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 11000.00488519
+            ans = prob['OD0.perf.Fg'][0]
+            print('Fg:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 0.783636794
-        ans = prob['OD0.perf.TSFC'][0]
-        print('TSFC:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 0.783636794
+            ans = prob['OD0.perf.TSFC'][0]
+            print('TSFC:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 1168.067147267
-        ans = prob['OD0.comp.Fl_O:tot:T'][0]
-        print('Tt3:', reg_data, ans)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 1168.067147267
+            ans = prob['OD0.comp.Fl_O:tot:T'][0]
+            print('Tt3:', reg_data, ans)
+            assert_near_equal(ans, reg_data, tol)
 
-        print()
-
+            print()
+        finally:
+            np.seterr(**old)
 
 if __name__ == "__main__":
     unittest.main()
 
-        

--- a/example_cycles/tests/benchmark_single_spool_turboshaft.py
+++ b/example_cycles/tests/benchmark_single_spool_turboshaft.py
@@ -48,89 +48,92 @@ class SingleSpoolTestCase(unittest.TestCase):
             prob[pt+'.fc.balance.Tt'] = 558.31
             prob[pt+'.turb.PR'] = 3.8768
             prob[pt+'.pt.PR'] = 2.8148
-        
+
 
         prob.set_solver_print(level=-1)
         prob.set_solver_print(level=2, depth=1)
 
-        np.seterr(divide='raise')
+        old = np.seterr(divide='raise')
 
-        prob.run_model()
-        tol = 1e-5
-        print()
+        try:
+            prob.run_model()
+            tol = 1e-5
+            print()
 
-        reg_data = 27.265344349
-        ans = prob['DESIGN.inlet.Fl_O:stat:W'][0]
-        print('W:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 27.265344349
+            ans = prob['DESIGN.inlet.Fl_O:stat:W'][0]
+            print('W:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 13.5
-        ans = prob['DESIGN.perf.OPR'][0]
-        print('OPR:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 13.5
+            ans = prob['DESIGN.perf.OPR'][0]
+            print('OPR:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 0.01755865988
-        ans = prob['DESIGN.balance.FAR'][0]
-        print('Main FAR:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 0.01755865988
+            ans = prob['DESIGN.balance.FAR'][0]
+            print('Main FAR:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 3.876811443516
-        ans = prob['DESIGN.balance.turb_PR'][0]
-        print('HPT PR:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 3.876811443516
+            ans = prob['DESIGN.balance.turb_PR'][0]
+            print('HPT PR:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 800.85349568
-        ans = prob['DESIGN.perf.Fg'][0]
-        print('Fg:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 800.85349568
+            ans = prob['DESIGN.perf.Fg'][0]
+            print('Fg:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 2.15204967
-        ans = prob['DESIGN.perf.TSFC'][0]
-        print('TSFC:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 2.15204967
+            ans = prob['DESIGN.perf.TSFC'][0]
+            print('TSFC:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 1190.1777648
-        ans = prob['DESIGN.comp.Fl_O:tot:T'][0]
-        print('Tt3:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 1190.1777648
+            ans = prob['DESIGN.comp.Fl_O:tot:T'][0]
+            print('Tt3:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        print('#'*10)
-        print('# OD')
-        print('#'*10)
-        reg_data = 25.8972423
-        ans = prob['OD.inlet.Fl_O:stat:W'][0]
-        print('W:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            print('#'*10)
+            print('# OD')
+            print('#'*10)
+            reg_data = 25.8972423
+            ans = prob['OD.inlet.Fl_O:stat:W'][0]
+            print('W:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 12.4297249
-        ans = prob['OD.perf.OPR'][0]
-        print('OPR:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 12.4297249
+            ans = prob['OD.perf.OPR'][0]
+            print('OPR:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 0.0163117040
-        ans = prob['OD.balance.FAR'][0]
-        print('Main FAR:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 0.0163117040
+            ans = prob['OD.balance.FAR'][0]
+            print('Main FAR:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 7853.754354
-        ans = prob['OD.balance.HP_Nmech'][0]
-        print('HP Nmech:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 7853.754354
+            ans = prob['OD.balance.HP_Nmech'][0]
+            print('HP Nmech:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 696.62110739
-        ans = prob['OD.perf.Fg'][0]
-        print('Fg:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 696.62110739
+            ans = prob['OD.perf.Fg'][0]
+            print('Fg:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 2.5063687
-        ans = prob['OD.perf.TSFC'][0]
-        print('TSFC:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 2.5063687
+            ans = prob['OD.perf.TSFC'][0]
+            print('TSFC:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
 
-        reg_data = 1158.519646
-        ans = prob['OD.comp.Fl_O:tot:T'][0]
-        print('Tt3:', ans, reg_data)
-        assert_near_equal(ans, reg_data, tol)
+            reg_data = 1158.519646
+            ans = prob['OD.comp.Fl_O:tot:T'][0]
+            print('Tt3:', ans, reg_data)
+            assert_near_equal(ans, reg_data, tol)
+        finally:
+            np.seterr(**old)
 
 
 if __name__ == "__main__":

--- a/pycycle/elements/test/test_ambient.py
+++ b/pycycle/elements/test/test_ambient.py
@@ -30,31 +30,33 @@ class FlowStartTestCase(unittest.TestCase):
         self.prob.setup(check=False, force_alloc_complex=True)
 
     def test_case1(self):
-        np.seterr(divide='raise')
-        # 6 cases to check against
-        for i, data in enumerate(ref_data):
-            self.prob['amb.alt'] = data[h_map['alt']]
-            self.prob['amb.dTs'] = data[h_map['dTs']]
+        old = np.seterr(divide='raise')
+        try:
+            # 6 cases to check against
+            for i, data in enumerate(ref_data):
+                self.prob['amb.alt'] = data[h_map['alt']]
+                self.prob['amb.dTs'] = data[h_map['dTs']]
 
-            self.prob.run_model()
+                self.prob.run_model()
 
-            # check outputs
-            tol = 1.0e-2 # seems a little generous
+                # check outputs
+                tol = 1.0e-2 # seems a little generous
 
-            npss = data[h_map['Ps']]
-            pyc = self.prob['amb.Ps']
-            rel_err = abs(npss - pyc)/npss
-            self.assertLessEqual(rel_err, tol)
+                npss = data[h_map['Ps']]
+                pyc = self.prob['amb.Ps']
+                rel_err = abs(npss - pyc)/npss
+                self.assertLessEqual(rel_err, tol)
 
-            npss = data[h_map['Ts']]
-            pyc = self.prob['amb.Ts']
-            rel_err = abs(npss - pyc)/npss
-            self.assertLessEqual(rel_err, tol)
+                npss = data[h_map['Ts']]
+                pyc = self.prob['amb.Ts']
+                rel_err = abs(npss - pyc)/npss
+                self.assertLessEqual(rel_err, tol)
 
-            partial_data = self.prob.check_partials(out_stream=None, method='cs', 
-                                                    includes=['amb.*'], excludes=['*.base_thermo.*', 'amb.readAtmTable'])
-            assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
-
+                partial_data = self.prob.check_partials(out_stream=None, method='cs',
+                                                        includes=['amb.*'], excludes=['*.base_thermo.*', 'amb.readAtmTable'])
+                assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
+        finally:
+            np.seterr(**old)
 
 
 if __name__ == "__main__":

--- a/pycycle/elements/test/test_compressor.py
+++ b/pycycle/elements/test/test_compressor.py
@@ -68,70 +68,73 @@ class CompressorTestCase(unittest.TestCase):
         self.prob.setup(check=False, force_alloc_complex=True)
 
     def test_case1(self):
-        np.seterr(divide='raise')
-        # 6 cases to check against
-        for i, data in enumerate(ref_data):
-            self.prob['compressor.PR'] = data[h_map['comp.PRdes']]
-            self.prob['compressor.eff'] = data[h_map['comp.effDes']]
-            self.prob['compressor.MN'] = data[h_map['comp.Fl_O.MN']]
+        old = np.seterr(divide='raise')
+        try:
+            # 6 cases to check against
+            for i, data in enumerate(ref_data):
+                self.prob['compressor.PR'] = data[h_map['comp.PRdes']]
+                self.prob['compressor.eff'] = data[h_map['comp.effDes']]
+                self.prob['compressor.MN'] = data[h_map['comp.Fl_O.MN']]
 
-            # input flowstation
-            self.prob['flow_start.P'] = data[h_map['start.Pt']]
-            self.prob['flow_start.T'] = data[h_map['start.Tt']]
-            self.prob['flow_start.W'] = data[h_map['start.W']]
-            self.prob.run_model()
+                # input flowstation
+                self.prob['flow_start.P'] = data[h_map['start.Pt']]
+                self.prob['flow_start.T'] = data[h_map['start.Tt']]
+                self.prob['flow_start.W'] = data[h_map['start.W']]
+                self.prob.run_model()
 
-            tol = 1e-3
+                tol = 1e-3
 
-            npss = data[h_map['comp.Fl_O.Pt']]
-            pyc = self.prob['compressor.Fl_O:tot:P'][0]
-            print('Pt out:', npss, pyc)
-            assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['comp.Fl_O.Pt']]
+                pyc = self.prob['compressor.Fl_O:tot:P'][0]
+                print('Pt out:', npss, pyc)
+                assert_near_equal(pyc, npss, tol)
 
-            npss = data[h_map['comp.Fl_O.Tt']]
-            pyc = self.prob['compressor.Fl_O:tot:T'][0]
-            print('Tt out:', npss, pyc)
-            assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['comp.Fl_O.Tt']]
+                pyc = self.prob['compressor.Fl_O:tot:T'][0]
+                print('Tt out:', npss, pyc)
+                assert_near_equal(pyc, npss, tol)
 
-            npss = data[h_map['comp.Fl_O.ht']] - data[h_map['start.Fl_O.ht']]
-            pyc = self.prob['compressor.Fl_O:tot:h'] - self.prob['flow_start.Fl_O:tot:h']
-            print('delta h:', npss, pyc)
-            assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['comp.Fl_O.ht']] - data[h_map['start.Fl_O.ht']]
+                pyc = self.prob['compressor.Fl_O:tot:h'] - self.prob['flow_start.Fl_O:tot:h']
+                print('delta h:', npss, pyc)
+                assert_near_equal(pyc, npss, tol)
 
-            npss = data[h_map['start.Fl_O.s']]
-            pyc = self.prob['flow_start.Fl_O:tot:S'][0]
-            print('S in:', npss, pyc)
-            assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['start.Fl_O.s']]
+                pyc = self.prob['flow_start.Fl_O:tot:S'][0]
+                print('S in:', npss, pyc)
+                assert_near_equal(pyc, npss, tol)
 
-            npss = data[h_map['comp.Fl_O.s']]
-            pyc = self.prob['compressor.Fl_O:tot:S'][0]
-            print('S out:', npss, pyc)
-            assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['comp.Fl_O.s']]
+                pyc = self.prob['compressor.Fl_O:tot:S'][0]
+                print('S out:', npss, pyc)
+                assert_near_equal(pyc, npss, tol)
 
-            npss = data[h_map['comp.pwr']]
-            pyc = self.prob['compressor.power'][0]
-            print('Power:', npss, pyc)
-            assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['comp.pwr']]
+                pyc = self.prob['compressor.power'][0]
+                print('Power:', npss, pyc)
+                assert_near_equal(pyc, npss, tol)
 
-            npss = data[h_map['Fl_O.Ps']]
-            pyc = self.prob['compressor.Fl_O:stat:P'][0]
-            print('Ps out:', npss, pyc)
-            assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['Fl_O.Ps']]
+                pyc = self.prob['compressor.Fl_O:stat:P'][0]
+                print('Ps out:', npss, pyc)
+                assert_near_equal(pyc, npss, tol)
 
-            npss = data[h_map['Fl_O.Ts']]
-            pyc = self.prob['compressor.Fl_O:stat:T'][0]
-            print('Ts out:', npss, pyc)
-            assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['Fl_O.Ts']]
+                pyc = self.prob['compressor.Fl_O:stat:T'][0]
+                print('Ts out:', npss, pyc)
+                assert_near_equal(pyc, npss, tol)
 
-            npss = data[h_map['comp.effPoly']]
-            pyc = self.prob['compressor.eff_poly'][0]
-            print('effPoly:', npss, pyc)
-            assert_near_equal(pyc, npss, tol)
-            print("")
+                npss = data[h_map['comp.effPoly']]
+                pyc = self.prob['compressor.eff_poly'][0]
+                print('effPoly:', npss, pyc)
+                assert_near_equal(pyc, npss, tol)
+                print("")
 
-            partial_data = self.prob.check_partials(out_stream=None, method='cs', 
-                                                    includes=['compressor.*'], excludes=['*.base_thermo.*',])
-            assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
+                partial_data = self.prob.check_partials(out_stream=None, method='cs',
+                                                        includes=['compressor.*'], excludes=['*.base_thermo.*',])
+                assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
+        finally:
+            np.seterr(**old)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pycycle/elements/test/test_compressor_od.py
+++ b/pycycle/elements/test/test_compressor_od.py
@@ -61,7 +61,6 @@ class CompressorODTestCase(unittest.TestCase):
         self.prob.setup(check=False, force_alloc_complex=True)
 
     def test_case1(self):
-        np.seterr(divide='raise')
 
         fpath = os.path.dirname(os.path.realpath(__file__))
         ref_data = np.loadtxt(fpath + "/reg_data/compressorOD1.csv",
@@ -111,99 +110,107 @@ class CompressorODTestCase(unittest.TestCase):
             'comp.SMN']
 
         h_map = dict(((v_name, i) for i, v_name in enumerate(header)))
-        # 6 cases to check against
-        for i, data in enumerate(ref_data):
-                self.prob['compressor.s_PR'] = data[h_map['comp.s_PRdes']]
-                self.prob['compressor.s_Wc'] = data[h_map['comp.s_WcDes']]
-                self.prob['compressor.s_eff'] = data[h_map['comp.s_effDes']]
-                self.prob['compressor.s_Nc'] = data[h_map['comp.s_NcDes']]
-                self.prob['compressor.map.RlineMap'] = data[h_map['comp.RlineMap']]
-                self.prob['compressor.Nmech'] = data[h_map['shaft.Nmech']]
 
-                # input flowstation
-                self.prob['flow_start.P'] = data[h_map['comp.Fl_I.Pt']]
-                self.prob['flow_start.T'] = data[h_map['comp.Fl_I.Tt']]
-                self.prob['flow_start.W'] = data[h_map['comp.Fl_I.W']]
-                self.prob['compressor.area'] = data[h_map['comp.Fl_O.A']]
+        old = np.seterr(divide='raise')
 
-                self.prob.run_model()
-                tol = 3.0e-3  # seems a little generous,
-                # FL_O.Ps is off by 4% or less, everything else is <1% tol
+        try:
+            # 6 cases to check against
+            for i, data in enumerate(ref_data):
+                    self.prob['compressor.s_PR'] = data[h_map['comp.s_PRdes']]
+                    self.prob['compressor.s_Wc'] = data[h_map['comp.s_WcDes']]
+                    self.prob['compressor.s_eff'] = data[h_map['comp.s_effDes']]
+                    self.prob['compressor.s_Nc'] = data[h_map['comp.s_NcDes']]
+                    self.prob['compressor.map.RlineMap'] = data[h_map['comp.RlineMap']]
+                    self.prob['compressor.Nmech'] = data[h_map['shaft.Nmech']]
 
-                print('----- Test Case', i, '-----')
-                npss = data[h_map['comp.Fl_I.Pt']]
-                pyc = self.prob['flow_start.Fl_O:tot:P'][0]
-                print('Pt in:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    # input flowstation
+                    self.prob['flow_start.P'] = data[h_map['comp.Fl_I.Pt']]
+                    self.prob['flow_start.T'] = data[h_map['comp.Fl_I.Tt']]
+                    self.prob['flow_start.W'] = data[h_map['comp.Fl_I.W']]
+                    self.prob['compressor.area'] = data[h_map['comp.Fl_O.A']]
 
-                npss = data[h_map['comp.Fl_I.s']]
-                pyc = self.prob['flow_start.Fl_O:tot:S'][0]
-                print('S in:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    self.prob.run_model()
+                    tol = 3.0e-3  # seems a little generous,
+                    # FL_O.Ps is off by 4% or less, everything else is <1% tol
 
-                npss = data[h_map['comp.Fl_I.W']]
-                pyc = self.prob['compressor.Fl_O:stat:W'][0]
-                print('W in:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    print('----- Test Case', i, '-----')
+                    npss = data[h_map['comp.Fl_I.Pt']]
+                    pyc = self.prob['flow_start.Fl_O:tot:P'][0]
+                    print('Pt in:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.Fl_I.s']]
-                pyc = self.prob['flow_start.Fl_O:tot:S'][0]
-                print('S in:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    npss = data[h_map['comp.Fl_I.s']]
+                    pyc = self.prob['flow_start.Fl_O:tot:S'][0]
+                    print('S in:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.RlineMap']]
-                pyc = self.prob['compressor.map.RlineMap'][0]
-                print('RlineMap:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    npss = data[h_map['comp.Fl_I.W']]
+                    pyc = self.prob['compressor.Fl_O:stat:W'][0]
+                    print('W in:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.PR']]
-                pyc = self.prob['compressor.PR'][0]
-                print('PR:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    npss = data[h_map['comp.Fl_I.s']]
+                    pyc = self.prob['flow_start.Fl_O:tot:S'][0]
+                    print('S in:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.eff']]
-                pyc = self.prob['compressor.eff'][0]
-                print('eff:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    npss = data[h_map['comp.RlineMap']]
+                    pyc = self.prob['compressor.map.RlineMap'][0]
+                    print('RlineMap:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.Fl_O.ht']] - data[h_map['comp.Fl_I.ht']]
-                pyc = self.prob['compressor.Fl_O:tot:h'][0] - self.prob['flow_start.Fl_O:tot:h'][0]
-                print('delta h:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    npss = data[h_map['comp.PR']]
+                    pyc = self.prob['compressor.PR'][0]
+                    print('PR:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.Fl_O.s']]
-                pyc = self.prob['compressor.Fl_O:tot:S'][0]
-                print('S out:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    npss = data[h_map['comp.eff']]
+                    pyc = self.prob['compressor.eff'][0]
+                    print('eff:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.pwr']]
-                pyc = self.prob['compressor.power'][0]
-                print('Power:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    npss = data[h_map['comp.Fl_O.ht']] - data[h_map['comp.Fl_I.ht']]
+                    pyc = self.prob['compressor.Fl_O:tot:h'][0] - self.prob['flow_start.Fl_O:tot:h'][0]
+                    print('delta h:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.Fl_O.Ps']]
-                pyc = self.prob['compressor.Fl_O:stat:P'][0]
-                print('Ps out:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    npss = data[h_map['comp.Fl_O.s']]
+                    pyc = self.prob['compressor.Fl_O:tot:S'][0]
+                    print('S out:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.Fl_O.Ts']]
-                pyc = self.prob['compressor.Fl_O:stat:T'][0]
-                print('Ts out:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    npss = data[h_map['comp.pwr']]
+                    pyc = self.prob['compressor.power'][0]
+                    print('Power:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.SMW']]
-                pyc = self.prob['compressor.SMW'][0]
-                print('SMW:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
+                    npss = data[h_map['comp.Fl_O.Ps']]
+                    pyc = self.prob['compressor.Fl_O:stat:P'][0]
+                    print('Ps out:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                npss = data[h_map['comp.SMN']]
-                pyc = self.prob['compressor.SMN'][0]
-                print('SMN:', npss, pyc)
-                assert_near_equal(pyc, npss, tol)
-                print()
+                    npss = data[h_map['comp.Fl_O.Ts']]
+                    pyc = self.prob['compressor.Fl_O:stat:T'][0]
+                    print('Ts out:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
 
-                partial_data = self.prob.check_partials(out_stream=None, method='cs', 
-                                                    includes=['compressor.*'], excludes=['*.base_thermo.*',])
-                assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
+                    npss = data[h_map['comp.SMW']]
+                    pyc = self.prob['compressor.SMW'][0]
+                    print('SMW:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
+
+                    npss = data[h_map['comp.SMN']]
+                    pyc = self.prob['compressor.SMN'][0]
+                    print('SMN:', npss, pyc)
+                    assert_near_equal(pyc, npss, tol)
+                    print()
+
+                    partial_data = self.prob.check_partials(out_stream=None, method='cs',
+                                                        includes=['compressor.*'], excludes=['*.base_thermo.*',])
+                    assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
+        finally:
+            np.seterr(**old)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pycycle/elements/test/test_duct.py
+++ b/pycycle/elements/test/test_duct.py
@@ -44,8 +44,6 @@ header = [
     'Fl_O.gams']
 h_map = dict(((v_name, i) for i, v_name in enumerate(header)))
 
-np.seterr(all="raise")
-
 
 class DuctTestCase(unittest.TestCase):
 
@@ -102,7 +100,7 @@ class DuctTestCase(unittest.TestCase):
             assert_near_equal(ps_computed, ps, tol)
             assert_near_equal(ts_computed, ts, tol)
 
-            partial_data = self.prob.check_partials(out_stream=None, method='cs', 
+            partial_data = self.prob.check_partials(out_stream=None, method='cs',
                                                     includes=['duct.*'], excludes=['*.base_thermo.*',])
             assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 
@@ -116,7 +114,7 @@ class DuctTestCase(unittest.TestCase):
         cycle_DES = self.prob.model.add_subsystem('DESIGN', Cycle())
         cycle_DES.options['thermo_method'] = 'CEA'
         cycle_DES.options['thermo_data'] = species_data.janaf
-        
+
         cycle_OD = self.prob.model.add_subsystem('OFF_DESIGN', Cycle())
         cycle_OD.options['design'] = False
         cycle_OD.options['thermo_method'] = 'CEA'
@@ -124,7 +122,7 @@ class DuctTestCase(unittest.TestCase):
 
 
         cycle_DES.add_subsystem('flow_start', FlowStart(), promotes=['P', 'T', 'MN', 'W'])
-        
+
         cycle_OD.add_subsystem('flow_start_OD', FlowStart(), promotes=['P', 'T', 'W', 'MN'])
 
         expMN = 1.0
@@ -189,7 +187,7 @@ class DuctTestCase(unittest.TestCase):
         assert_near_equal(ps_computed, 8.26348914, tol)
         assert_near_equal(ts_computed, ts, tol)
 
-        partial_data = self.prob.check_partials(out_stream=None, method='cs', 
+        partial_data = self.prob.check_partials(out_stream=None, method='cs',
                                                     includes=['duct.*'], excludes=['*.base_thermo.*',])
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
 

--- a/pycycle/elements/test/test_flow_start.py
+++ b/pycycle/elements/test/test_flow_start.py
@@ -5,8 +5,8 @@ import os
 from openmdao.api import Problem, Group
 from openmdao.utils.assert_utils import assert_near_equal
 
-from pycycle.api import (Cycle, FlowStart, CEA_AIR_COMPOSITION, 
-                         CEA_WET_AIR_COMPOSITION, species_data, AIR_JETA_TAB_SPEC, 
+from pycycle.api import (Cycle, FlowStart, CEA_AIR_COMPOSITION,
+                         CEA_WET_AIR_COMPOSITION, species_data, AIR_JETA_TAB_SPEC,
                          TAB_AIR_FUEL_COMPOSITION)
 
 fpath = os.path.dirname(os.path.realpath(__file__))
@@ -34,7 +34,7 @@ h_map = dict(((v_name, i) for i, v_name in enumerate(header)))
 
 
 class FlowStartTestCase(unittest.TestCase):
-    
+
     def test_case1(self):
 
         self.prob = Problem()
@@ -43,117 +43,120 @@ class FlowStartTestCase(unittest.TestCase):
         self.prob.model.set_input_defaults('fl_start.MN', 0.5)
         self.prob.model.set_input_defaults('fl_start.W', 100., units='lbm/s')
 
-        fl_start = self.prob.model.add_subsystem('fl_start', FlowStart(thermo_method='CEA', 
-                                                                       thermo_data=species_data.janaf, 
+        fl_start = self.prob.model.add_subsystem('fl_start', FlowStart(thermo_method='CEA',
+                                                                       thermo_data=species_data.janaf,
                                                                        composition=CEA_AIR_COMPOSITION))
 
         #note: must manually call this for stand alone element tests without a cycle group
-        fl_start.pyc_setup_output_ports() 
+        fl_start.pyc_setup_output_ports()
 
         self.prob.set_solver_print(level=-1)
         self.prob.setup(check=False)
 
-        np.seterr(divide='raise')
-        # 6 cases to check against
-        for i, data in enumerate(ref_data):
+        old = np.seterr(divide='raise')
+        try:
+            # 6 cases to check against
+            for i, data in enumerate(ref_data):
 
-            if i != 4: 
-                continue 
+                if i != 4:
+                    continue
 
-            self.prob.set_val('fl_start.P',data[h_map['Pt']], units='psi')
-            self.prob['fl_start.T'] = data[h_map['Tt']]
-            self.prob['fl_start.W'] = data[h_map['W']]
-            self.prob['fl_start.MN'] = data[h_map['MN']]
+                self.prob.set_val('fl_start.P',data[h_map['Pt']], units='psi')
+                self.prob['fl_start.T'] = data[h_map['Tt']]
+                self.prob['fl_start.W'] = data[h_map['W']]
+                self.prob['fl_start.MN'] = data[h_map['MN']]
 
-            self.prob.run_model()
+                self.prob.run_model()
 
-            # check outputs
-            tol = 1.0e-3
+                # check outputs
+                tol = 1.0e-3
 
-            # The Mach 2.0 case is at a ridiculously low temperature, so accuracy is questionable
-            if data[h_map['MN']] >= 2.:  
-                tol = 5e-2
+                # The Mach 2.0 case is at a ridiculously low temperature, so accuracy is questionable
+                if data[h_map['MN']] >= 2.:
+                    tol = 5e-2
 
-            print(
-                'Case: ', data[
-                    h_map['Pt']], data[
-                    h_map['Tt']], data[
-                    h_map['W']], data[
-                    h_map['MN']])
-            npss = data[h_map['Pt']]
-            pyc = self.prob['fl_start.Fl_O:tot:P']
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['Tt']]
-            pyc = self.prob['fl_start.Fl_O:tot:T']
-            rel_err = abs(npss - pyc) / npss
-            print('Tt:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['W']]
-            pyc = self.prob['fl_start.Fl_O:stat:W']
-            rel_err = abs(npss - pyc) / npss
-            print('W:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['ht']]
-            pyc = self.prob['fl_start.Fl_O:tot:h']
-            rel_err = abs(npss - pyc) / npss
-            print('ht:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['s']]
-            pyc = self.prob['fl_start.Fl_O:tot:S']
-            rel_err = abs(npss - pyc) / npss
-            print('S:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['rhot']]
-            pyc = self.prob['fl_start.Fl_O:tot:rho']
-            rel_err = abs(npss - pyc) / npss
-            print('rhot:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['gamt']]
-            pyc = self.prob['fl_start.Fl_O:tot:gamma']
-            rel_err = abs(npss - pyc) / npss
-            print('gamt:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['MN']]
-            pyc = self.prob['fl_start.Fl_O:stat:MN']
-            rel_err = abs(npss - pyc) / npss
-            print('MN:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['Ps']]
-            pyc = self.prob['fl_start.Fl_O:stat:P']
-            rel_err = abs(npss - pyc) / npss
-            print('Ps:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['Ts']]
-            pyc = self.prob['fl_start.Fl_O:stat:T']
-            rel_err = abs(npss - pyc) / npss
-            print('Ts:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['hs']]
-            pyc = self.prob['fl_start.Fl_O:stat:h']
-            rel_err = abs(npss - pyc) / npss
-            print('hs:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['rhos']]
-            pyc = self.prob['fl_start.Fl_O:stat:rho']
-            rel_err = abs(npss - pyc) / npss
-            print('rhos:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['gams']]
-            pyc = self.prob['fl_start.Fl_O:stat:gamma']
-            rel_err = abs(npss - pyc) / npss
-            print('gams:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['V']]
-            pyc = self.prob['fl_start.Fl_O:stat:V']
-            rel_err = abs(npss - pyc) / npss
-            print('V:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            npss = data[h_map['A']]
-            pyc = self.prob['fl_start.Fl_O:stat:area']
-            rel_err = abs(npss - pyc) / npss
-            print('A:', npss, pyc, rel_err)
-            assert_near_equal(pyc, npss, tol)
-            print()
+                print(
+                    'Case: ', data[
+                        h_map['Pt']], data[
+                        h_map['Tt']], data[
+                        h_map['W']], data[
+                        h_map['MN']])
+                npss = data[h_map['Pt']]
+                pyc = self.prob['fl_start.Fl_O:tot:P']
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['Tt']]
+                pyc = self.prob['fl_start.Fl_O:tot:T']
+                rel_err = abs(npss - pyc) / npss
+                print('Tt:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['W']]
+                pyc = self.prob['fl_start.Fl_O:stat:W']
+                rel_err = abs(npss - pyc) / npss
+                print('W:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['ht']]
+                pyc = self.prob['fl_start.Fl_O:tot:h']
+                rel_err = abs(npss - pyc) / npss
+                print('ht:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['s']]
+                pyc = self.prob['fl_start.Fl_O:tot:S']
+                rel_err = abs(npss - pyc) / npss
+                print('S:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['rhot']]
+                pyc = self.prob['fl_start.Fl_O:tot:rho']
+                rel_err = abs(npss - pyc) / npss
+                print('rhot:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['gamt']]
+                pyc = self.prob['fl_start.Fl_O:tot:gamma']
+                rel_err = abs(npss - pyc) / npss
+                print('gamt:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['MN']]
+                pyc = self.prob['fl_start.Fl_O:stat:MN']
+                rel_err = abs(npss - pyc) / npss
+                print('MN:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['Ps']]
+                pyc = self.prob['fl_start.Fl_O:stat:P']
+                rel_err = abs(npss - pyc) / npss
+                print('Ps:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['Ts']]
+                pyc = self.prob['fl_start.Fl_O:stat:T']
+                rel_err = abs(npss - pyc) / npss
+                print('Ts:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['hs']]
+                pyc = self.prob['fl_start.Fl_O:stat:h']
+                rel_err = abs(npss - pyc) / npss
+                print('hs:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['rhos']]
+                pyc = self.prob['fl_start.Fl_O:stat:rho']
+                rel_err = abs(npss - pyc) / npss
+                print('rhos:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['gams']]
+                pyc = self.prob['fl_start.Fl_O:stat:gamma']
+                rel_err = abs(npss - pyc) / npss
+                print('gams:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['V']]
+                pyc = self.prob['fl_start.Fl_O:stat:V']
+                rel_err = abs(npss - pyc) / npss
+                print('V:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                npss = data[h_map['A']]
+                pyc = self.prob['fl_start.Fl_O:stat:area']
+                rel_err = abs(npss - pyc) / npss
+                print('A:', npss, pyc, rel_err)
+                assert_near_equal(pyc, npss, tol)
+                print()
+        finally:
+            np.seterr(**old)
 
     def test_case_tabular_thermo(self):
 
@@ -163,8 +166,8 @@ class FlowStartTestCase(unittest.TestCase):
         prob.model.set_input_defaults('fl_start.MN', 0.5)
         prob.model.set_input_defaults('fl_start.W', 100., units='lbm/s')
 
-        fl_start = prob.model.add_subsystem('fl_start', FlowStart(thermo_method='TABULAR', 
-                                                                  thermo_data=AIR_JETA_TAB_SPEC, 
+        fl_start = prob.model.add_subsystem('fl_start', FlowStart(thermo_method='TABULAR',
+                                                                  thermo_data=AIR_JETA_TAB_SPEC,
                                                                   composition=TAB_AIR_FUEL_COMPOSITION))
         fl_start.pyc_setup_output_ports() #note: must manually call this for stand alone element tests without a cycle group
 
@@ -189,10 +192,10 @@ class FlowStartTestCase(unittest.TestCase):
         assert_near_equal(prob['fl_start.Fl_O:stat:MN'], 0.8, tol)
         assert_near_equal(prob['fl_start.Fl_O:stat:area'], 778.26812382, tol)
 
-   
+
 class WARTestCase(unittest.TestCase):
 
-    def test_fs_with_water(self): 
+    def test_fs_with_water(self):
 
         prob = Problem()
         prob.model.set_input_defaults('fl_start.P', 17., units='psi')
@@ -201,8 +204,8 @@ class WARTestCase(unittest.TestCase):
         prob.model.set_input_defaults('fl_start.W', 100., units='lbm/s')
         prob.model.set_input_defaults('fl_start.WAR', .01)
 
-        fl_start = prob.model.add_subsystem('fl_start', FlowStart(thermo_data=species_data.wet_air, 
-                                                                  composition=CEA_WET_AIR_COMPOSITION, 
+        fl_start = prob.model.add_subsystem('fl_start', FlowStart(thermo_data=species_data.wet_air,
+                                                                  composition=CEA_WET_AIR_COMPOSITION,
                                                                   reactant="Water", mix_ratio_name='WAR'))
         fl_start.pyc_setup_output_ports()
 
@@ -220,6 +223,6 @@ class WARTestCase(unittest.TestCase):
         assert_near_equal(prob['fl_start.Fl_O:tot:composition'][3], 5.305198e-02, tol)
         assert_near_equal(prob['fl_start.Fl_O:tot:composition'][4], 1.51432e-02, tol)
 
-    
+
 if __name__ == "__main__":
     unittest.main()

--- a/pycycle/thermo/static_ps_resid.py
+++ b/pycycle/thermo/static_ps_resid.py
@@ -106,13 +106,13 @@ class PsResid(om.ImplicitComponent):
     def _compute_outputs_MN(self, i):
 
         Vsonic = (i['gamma']*i['R']*i['Ts'])**0.5
+        old = np.seterr(all='raise')
         try:
-            np.seterr(all='raise')
             Vsonic = (i['gamma']*i['R']*i['Ts'])**0.5
-            np.seterr(all='warn')
         except:
-            np.seterr(all='warn')
             print(self.pathname, i['gamma'], i['R'], i['Ts'])
+        finally:
+            np.seterr(**old)
 
         MN = i['MN']
         if MN < 1e-16:
@@ -133,17 +133,17 @@ class PsResid(om.ImplicitComponent):
             #MN = i['W']/(i['rho']*Vsonic*i['area'])
             #print("MN_calc", self.pathname, i['W'], i['rho'], Vsonic, i['area'])
 
+            old = np.seterr(all='raise')
             try:
-                np.seterr(all='raise')
                 MN = i['W']/(i['rho']*Vsonic*i['area'])
-                np.seterr(all='warn')
             except:
-                np.seterr(all='warn')
                 print("MN_calc", self.pathname, i['W'], i['rho'], Vsonic, i['area'])
                 MN = 5.
+            finally:
+                np.seterr(**old)
 
         V = MN*Vsonic
-        
+
         return MN, Vsonic, V
 
     def solve_nonlinear(self, inputs, outputs):


### PR DESCRIPTION
In several places in pyCycle the global error handling behavior was being set via np.seterr and was either not reset at all after the numerical operation was complete or was reset to some specific behavior like 'warn' which would override any previous settings.  This made it impossible to set the global error behavior while debugging a specific model that has pyCycle systems in it.  This PR puts a try..finally block around the numerical operation(s) and restores the previous behavior of np.seterr afterward.