### PR TITLE
Added missing design off design area connection in burner

### DIFF
--- a/pycycle/elements/combustor.py
+++ b/pycycle/elements/combustor.py
@@ -63,7 +63,7 @@ class Combustor(Element):
                              desc='Type of fuel.')
         
         self.default_des_od_conns = [
-            # (design src, off-design target)
+            #  (design src, off-design target)
             ('Fl_O:stat:area', 'area')
         ]
 


### PR DESCRIPTION
Added the missing design-off-design area connection in the burner, the default design-off-design area connection was missing.

The burner will return default area i.e. 1 in the off-design condition. 

All other components have a default area connection to the off-design except combuster.  
Calling the method("self.pyc_use_default_des_od_conns()") in the main program will connect the design area of combustor to the off design.