### PR TITLE
Remove cast conversion of an array with ndim > 0 to scalar

### DIFF
--- a/example_cycles/high_bypass_turbofan.py
+++ b/example_cycles/high_bypass_turbofan.py
@@ -246,9 +246,9 @@ def viewer(prob, pt, file=sys.stdout):
         HPT_PR = prob[pt+'.hpt.PR']
         FAR = prob[pt+'.balance.FAR']
 
-    summary_data = (MN, prob[pt+'.fc.alt'], prob[pt+'.inlet.Fl_O:stat:W'], prob[pt+'.perf.Fn'],
-                        prob[pt+'.perf.Fg'], prob[pt+'.inlet.F_ram'], prob[pt+'.perf.OPR'],
-                        prob[pt+'.perf.TSFC'], prob[pt+'.splitter.BPR'])
+    summary_data = (MN[0], prob[pt+'.fc.alt'][0], prob[pt+'.inlet.Fl_O:stat:W'][0], prob[pt+'.perf.Fn'][0],
+                        prob[pt+'.perf.Fg'][0], prob[pt+'.inlet.F_ram'][0], prob[pt+'.perf.OPR'][0],
+                        prob[pt+'.perf.TSFC'][0], prob[pt+'.splitter.BPR'][0])
 
     print(file=file, flush=True)
     print(file=file, flush=True)


### PR DESCRIPTION
Eliminate Numpy deprecation warning when running high bypass turbofan example. 
Note: it will become a TypeError in the future.

```
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  print(" %7.5f  %7.1f %7.3f %7.1f %7.1f %7.1f %7.3f  %7.5f  %7.3f" %summary_data, file=file, flush=True)
```


NumPy 1.25 deprecation message (merged on 2023-04-20): Only ndim-0 arrays are treated as scalars. NumPy used to treat all arrays of size 1 (e.g., np.array([3.14])) as scalars. In the future, this will be limited to arrays of ndim 0 (e.g., np.array(3.14)). See [Numpy 1.25 release notes](https://numpy.org/devdocs/release/1.25.0-notes.html#deprecations)

Proposed solution is to explicitly get first element of arrays.