### PR TITLE
declare explicit thermo_data when adding FlightConditions

### DIFF
--- a/pycycle/elements/flight_conditions.py
+++ b/pycycle/elements/flight_conditions.py
@@ -1,6 +1,7 @@
 import openmdao.api as om
 
 from pycycle.thermo.cea import species_data
+from pycycle.thermo.cea import thermo_data
 from pycycle.constants import THERMO_DEFAULT_COMPOSITIONS
 from pycycle.elements.ambient import Ambient
 from pycycle.elements.flow_start import FlowStart
@@ -115,7 +116,7 @@ if __name__ == "__main__":
     des_vars.add_output('dTs', 0.0, units='degR')
 
 
-    fc = p1.model.add_subsystem("fc", FlightConditions())
+    fc = p1.model.add_subsystem("fc", FlightConditions(thermo_data=thermo_data.wet_air))
 
     p1.model.connect('des_vars.W', 'fc.W')
     p1.model.connect('des_vars.alt', 'fc.alt')


### PR DESCRIPTION
### Summary

When trying to run flight_conditions.py for testing the results, an AttributeError is thrown.
Solution was to add explicit thermo_data when instantiating FlightConditions.

### Related Issues

- Resolves [issue #97](https://github.com/OpenMDAO/pyCycle/issues/97)

### Backwards incompatibilities

None

### New Dependencies

None
