### PR TITLE
setup the param for point instead of promoting it

### DIFF
--- a/pycycle/mp_cycle.py
+++ b/pycycle/mp_cycle.py
@@ -253,11 +253,11 @@ class MPCycle(om.Group):
         # then issue connections between the design and off-design points
 
         for param, (val, units) in self._cycle_params.items(): 
-            self.set_input_defaults(name=param, val=val, units=units)
-        
-            self.promotes(self._des_pnt.name, inputs=[param])
+            # set the default value for the design point
+            self.set_input_defaults(name=f"{self._des_pnt.name}.{param}", val=val, units=units)
+            # set the default value for all off-design points
             for pnt in self._od_pnts: 
-                self.promotes(pnt.name, inputs=[param])
+                self.set_input_defaults(name=f"{pnt.name}.{param}", val=val, units=units)
 
 
         for src, target in self._des_od_connections: 


### PR DESCRIPTION
### Summary

Solution for issue #100 

Currently, the cycle variables are set up using the function pyc_add_cycle_param, which calls the configure() function in the mp_cycle.py. The configure function is promoting the variables to the cycle. The openmdao: 3.39.0 version is causing the incompatibility here, as the variables need to be accessed as component.var instead of point.component.var. So, instead of promoting the variables, we can set the variables for each design and off-design point. 

 
This issue can be solved in two ways.
1. Going and updating all the output codes to print burner.dpqp instead of point.burner.dpqp. Similarly, for all the variables which are set using self.pyc_add_cycle_param
2. Changing the pyc_add_cycle_param() function pipeline, which can be solved by changing the function def configure(self) in the mp_cycle. (This pull request)

### Related Issues

- Resolves #100

### Backwards incompatibilities

None

### New Dependencies

None
