### PR TITLE
Fix for compatibility with  OpenMDAO:3.39

### DIFF
--- a/example_cycles/tests/test_all_examples.py
+++ b/example_cycles/tests/test_all_examples.py
@@ -1,0 +1,123 @@
+"""
+This script is designed to test run scripts located in a specified directory.
+It uses Python's unittest framework to dynamically generate test cases for each
+script that ends with '.py'.
+"""
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+from openmdao.utils.testing_utils import use_tempdirs
+from parameterized import parameterized
+
+# Address any issue that requires a skip.
+SKIP_EXAMPLES = {
+    "high_bypass_turbofan.py" : "Runtime is more than 25 min." ,
+    "tab_thermo_data_generator.py" : "Runtime is more than 25 min." ,
+}
+
+
+def find_examples():
+    """
+    Find and return a list of run scripts in the specified directory.
+
+    Returns
+    -------
+    list
+        A list of pathlib.Path objects pointing to the run scripts.
+    """
+    base_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '.')
+
+    run_files = []
+    for root, _, files in os.walk(base_dir):
+        for file in files:
+            if file.endswith('.py'):
+                run_files.append(Path(root) / file)
+
+        # Don't recurse into tests directory.
+        break
+
+    return run_files
+
+
+def example_name(testcase_func, param_num, param):
+    """
+    Returns a formatted case name for unit testing with decorator @parameterized.expand().
+    It is intended to be used when expand() is called with a list of strings
+    representing test case names.
+
+    Parameters
+    ----------
+    testcase_func : Any
+        This parameter is ignored.
+    param_num : Any
+        This parameter is ignored.
+    param : param
+        The param object containing the case name to be formatted.
+    """
+    return 'benchmark_example_' + param.args[0].name.replace('.py', '')
+
+
+@use_tempdirs
+class RunScriptTest(unittest.TestCase):
+    """
+    A test case class that uses unittest to run and test scripts with a timeout.
+
+    Attributes
+    ----------
+    base_directory : str
+        The base directory where the run scripts are located.
+    run_files : list
+        A list of paths to run scripts found in the base directory.
+
+    Methods
+    -------
+    setUpClass()
+        Class method to find all run scripts before tests are run.
+    find_run_files(base_dir)
+        Finds and returns all run scripts in the specified directory.
+    run_script(script_path)
+        Attempts to run a script with a timeout and handles errors.
+    test_run_scripts()
+        Generates a test for each run script with a timeout.
+    """
+
+    def run_script(self, script_path, max_allowable_time=1500):
+        """
+        Attempt to run a script with a 1500-second timeout and handle errors.
+
+        Parameters
+        ----------
+        script_path : pathlib.Path
+            The path to the script to be run.
+
+        Raises
+        ------
+        Exception
+            Any exception other than ImportError or TimeoutExpired that occurs while running the script.
+        """
+        with open(os.devnull, 'w') as devnull:
+            proc = subprocess.Popen(['python', script_path], stdout=devnull, stderr=subprocess.PIPE)
+        proc.wait(timeout=max_allowable_time)
+        (stdout, stderr) = proc.communicate()
+
+        if proc.returncode != 0:
+            if 'ImportError' in str(stderr):
+                self.skipTest(f'Skipped {script_path.name} due to ImportError')
+            else:
+                raise Exception(f'Error running {script_path.name}:\n{stderr.decode("utf-8")}')
+
+    @parameterized.expand(find_examples(), name_func=example_name)
+    def benchmark_run_scripts(self, example_path):
+        """Test each run script to ensure it executes without error."""
+        if example_path.name in SKIP_EXAMPLES:
+            reason = SKIP_EXAMPLES[example_path.name]
+            self.skipTest(f'Skipped {example_path.name}: {reason}.')
+
+        self.run_script(example_path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pycycle/api.py
+++ b/pycycle/api.py
@@ -1,6 +1,6 @@
-from pycycle.constants import (AIR_FUEL_MIX, AIR_MIX, WET_AIR_MIX, BTU_s2HP, HP_per_RPM_to_FT_LBF, 
-                               R_UNIVERSAL_SI, R_UNIVERSAL_ENG, g_c, MIN_VALID_CONCENTRATION, 
-                               T_STDeng, P_STDeng, P_REF, CEA_AIR_COMPOSITION, CEA_AIR_FUEL_COMPOSITION, 
+from pycycle.constants import (AIR_FUEL_MIX, AIR_MIX, WET_AIR_MIX, BTU_s2HP, HP_per_RPM_to_FT_LBF,
+                               R_UNIVERSAL_SI, R_UNIVERSAL_ENG, g_c, MIN_VALID_CONCENTRATION,
+                               T_STDeng, P_STDeng, P_REF, CEA_AIR_COMPOSITION, CEA_AIR_FUEL_COMPOSITION,
                                CEA_WET_AIR_COMPOSITION, AIR_JETA_TAB_SPEC, TAB_AIR_FUEL_COMPOSITION)
 
 from pycycle.thermo.cea import species_data

--- a/pycycle/viewers.py
+++ b/pycycle/viewers.py
@@ -10,7 +10,7 @@ except ImportError:
   plt = None
 
 
-def get_val(prob, point, element, var_name):
+def get_val(prob, point, element, var_name, units=None):
     """
     Get the value of the requested element from the OpenMDAO model.
 
@@ -24,12 +24,18 @@ def get_val(prob, point, element, var_name):
         Name of the pcycle element system.
     var_name: str
         Name of the variable to get.
+    units: str or None
+        Units for the return value. Default is None, which will return using the delared units.
+
+    Returns
+    float
+        Value of requested element.
     """
     try:
-        val = prob.get_val(f"{point}.{element}.{var_name}")
+        val = prob.get_val(f"{point}.{element}.{var_name}", units=units)
     except KeyError:
         # This is a cycle parameter.
-        val = prob.get_val(f"{element}.{var_name}")
+        val = prob.get_val(f"{element}.{var_name}", units=units)
 
     return val[0]
 


### PR DESCRIPTION
### Summary

1. Modified some of the viewers to adapt to the loss of hybrid promoted names in OpenMDAO 3.39.
2. Added a benchmark that runs the cycle examples so that we can be warned when something goes wrong with them.

### Related Issues

- Resolves #100 

### Backwards incompatibilities

None

### New Dependencies

None
