### PR TITLE
Fix `_allowed_out_args` used in `UnitCompBase`

### DIFF
--- a/pycycle/thermo/unit_comps.py
+++ b/pycycle/thermo/unit_comps.py
@@ -2,14 +2,15 @@ import inspect
 import numpy as np
 
 from openmdao.api import ExplicitComponent
+from openmdao.core.component import Component
 
-_full_out_args = inspect.getfullargspec(ExplicitComponent.add_output)
+_full_out_args = inspect.getfullargspec(Component.add_output)
 _allowed_out_args = set(_full_out_args.args[3:] + _full_out_args.kwonlyargs)
 
 
 class UnitCompBase(ExplicitComponent):
 
-    def initialize(self): 
+    def initialize(self):
         self.options.declare('fl_name')
 
     def setup_io(self):


### PR DESCRIPTION
### Summary

The `UnitCompBase` class inspects the input arguments of `ExplicitComponent.add_output` to get the set of metadata that should be copied from its inputs to it's outputs. However, [this PR](https://github.com/OpenMDAO/OpenMDAO/pull/3587) replaced most of the arguments of `ExplicitComponent.add_output` with `**kwargs`. The removes a bunch of entries from `_full_out_args` and results in several pieces of metadata, including `units` not being added to the outputs. I fixed this by simply inspecting the input arguments of `Component.add_output` instead.

Full disclosure, I have absolutely no idea how pyCycle works, or what exactly this `UnitCompBase` component does (other than just converting the units of some variables to imperial). There may well be a much better way to do this.

### Related Issues

- Resolves #

### Backwards incompatibilities

Compatible with OM 3.39 which is the last release before the change that necessitates this PR.

### New Dependencies

None
