### PR TITLE
fix: use .item() in ThermoAdd.compute() for NumPy 2.x + OpenMDAO 3.42 compatibility

### DIFF
--- a/pycycle/thermo/tabular/thermo_add.py
+++ b/pycycle/thermo/tabular/thermo_add.py
@@ -118,7 +118,7 @@ class ThermoAdd(om.ExplicitComponent):
                 W_air_mix = W_air_in # for reactant mode, we reference from the incoming air
                 W_other_mix = W_air_mix * ratio 
                 outputs[f'{mix_name}:W'] = W_other_mix
-                W_other_out[self.idx_compo] += W_other_mix
+                W_other_out[self.idx_compo] += W_other_mix.item()
                 W_out += W_other_mix
                 W_times_h += W_other_mix*inputs[f'{mix_name}:h']
 


### PR DESCRIPTION
Fixes a `TypeError` in `ThermoAdd.compute()` when running with NumPy 2.x and OpenMDAO 3.42+.

OpenMDAO 3.42.0 changed scalar inputs to be stored as `(1,)` arrays rather than scalars. NumPy 2.0 removed implicit scalar conversion on 1-element arrays, so `W_other_out[self.idx_compo] += W_other_mix` fails because it tries to broadcast a `(1,)` array into a 0-d indexed slot.

**Fix:** changed to `W_other_mix.item()` to extract a proper Python scalar before the in-place add.

Closes #116